### PR TITLE
sdbootutil.spec: Make sdbootutil-snapper a hard dependency

### DIFF
--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -37,6 +37,7 @@ Requires:       systemd-boot
 Requires:       jq
 Requires:       sed
 Supplements:    (systemd-boot and shim)
+Requires:       (%{name}-snapper if (snapper and btrfsprogs))
 
 %description
 Hook scripts to install shim along with systemd-boot
@@ -47,7 +48,6 @@ Requires:       %{name} = %{version}
 Requires:       btrfsprogs
 Requires:       sdbootutil >= %{version}-%{release}
 Requires:       snapper
-Supplements:    (snapper and btrfsprogs and sdbootutil)
 
 %description snapper
 Plugin scripts for snapper to handle BLS config files

--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -33,6 +33,7 @@ Summary:        script to install shim with sd-boot
 License:        MIT
 URL:            https://en.opensuse.org/openSUSE:Usr_merge
 Source:         %{name}-%{version}.tar
+Requires:       efibootmgr
 Requires:       systemd-boot
 Requires:       jq
 Requires:       sed


### PR DESCRIPTION
Make sure this is installed when sdbootutil is used on a system with snapper.