### PR TITLE
Add systemd-boot-update-grub.service

### DIFF
--- a/systemd-boot-update-grub.service
+++ b/systemd-boot-update-grub.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Automatic Boot Loader Update (grub.efi)
+ConditionPathExists=!/etc/initrd-release
+
+DefaultDependencies=no
+After=local-fs.target systemd-update-boot.service
+Before=sysinit.target systemd-update-done.service
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=-cp -a -u /boot/efi/EFI/systemd/systemd-boot%%ARCH%%.efi /boot/efi/EFI/systemd/grub.efi
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
Also add this service and systemd-boot-update.service in the multi-user.target.wants

Note: there is a very ugly part in the spec file. I need to enable the new service, and also another one provided by systemd. For doing that, instead of going for the preset path, I decided here to create an empty file, link it into the target and mark the empty service as `%ghost %{_unitdir}/systemd-boot-update.service`