### PR TITLE
Use new os-release and machine-id files

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -284,10 +284,45 @@ sedrootflags()
 	sed "${sed_arguments[@]}"
 }
 
+settle_entry_token()
+{
+	local snapshot="$1"
+	set_os_release "${snapshot}"
+	set_machine_id "${snapshot}"
+	[ -n "$machine_id" ] || err "Couldn't determine machine-id"
+	case "$arg_entry_token" in
+		""|auto)
+			if [ -s '/etc/kernel/entry-token' ]; then
+				read -r entry_token < '/etc/kernel/entry-token'
+			else
+				entry_token="$machine_id"
+				# bootctl has more here in case the machine id
+				# is random falls back to trying IMAGE_ID and
+				# ID, only them machine id. We assume there is
+				# a valid machine-id
+			fi
+			;;
+		machine-id) entry_token="$machine_id" ;;
+		os-id)
+			# shellcheck disable=SC2154
+			entry_token="$os_release_ID"
+			[ -n "$entry_token" ] || err "Missing ID"
+			;;
+		os-image)
+			# shellcheck disable=SC2154
+			entry_token="$os_release_IMAGE_ID"
+			[ -n "$entry_token" ] || err "Missing IMAGE_ID"
+			;;
+		*) entry_token="$arg_entry_token" ;;
+	esac
+	return 0
+}
+
 remove_kernel()
 {
 	local snapshot="$1"
 	local kernel_version="$2"
+	settle_entry_token "${snapshot}"
 	local id="$entry_token-$kernel_version${snapshot:+-$snapshot}.conf"
 	run_command_output bootctl unlink "$id"
 
@@ -346,11 +381,50 @@ set_snapper_title_and_sortkey()
 	sort_key="snapper-$sort_key"
 }
 
+set_os_release()
+{
+	local snapshot="$1"
+	local subvol=""
+	[ -z "$snapshot" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	os_release_files=(
+		"${subvol#"${subvol_prefix}"}/usr/lib/os-release"
+		"${subvol#"${subvol_prefix}"}/etc/os-release"
+	)
+
+	for file in "${os_release_files[@]}"; do
+		[ -f "$file" ] || continue
+		eval $(sed -ne '/^[A-Z_]\+=/s/^/os_release_/p' < "$file")
+		break
+	done
+}
+
+set_machine_id()
+{
+	local snapshot="$1"
+	local subvol=""
+	[ -z "$snapshot" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	machine_id_files=()
+	if is_transactional; then
+		[ -n "$snapshot" ] && machine_id_files+=("/var/lib/overlay/$snapshot/etc/machine-id")
+	fi
+	machine_id_files+=(
+		"${subvol#"${subvol_prefix}"}/etc/machine-id"
+	)
+
+	for file in "${machine_id_files[@]}"; do
+		if [ -s "$file" ]; then
+			read -r machine_id < "$file"
+			break
+		fi
+	done
+}
+
 reuse_initrd() {
 	local snapshot="$1"
 	local subvol="$2"
 
 	[ -z "$arg_no_reuse_initrd" ] || return 1
+	settle_entry_token "${snapshot}"
 
 	local conf="$boot_root/loader/entries/$entry_token-$kernel_version-$snapshot.conf"
 	if [ -e "$conf" ]; then
@@ -367,6 +441,9 @@ reuse_initrd() {
 	# check if we can reuse the initrd from the parent
 	# to avoid expensive regeneration
 	detect_parent "$subvol"
+	if [ -n "$parent_snapshot" ]; then
+		settle_entry_token "$parent_snapshot"
+	fi
 	local parent_conf="$boot_root/loader/entries/$entry_token-$kernel_version-$parent_snapshot.conf"
 	if [ -n "$parent_subvol" ] && [ -e "$parent_conf" ]; then
 		#subvol_is_ro "$parent_subvol" || err "Parent snapshot $parent_snapshot is not read-only, can't reuse initrd"
@@ -425,6 +502,7 @@ install_kernel()
 	[ -e "$src" ] || err "Can't find $src"
 
 	calc_chksum "$src"
+	settle_entry_token "${snapshot}"
 	local dst="/$entry_token/$kernel_version/linux-$chksum"
 
 	local initrd="${src%/*}/initrd"
@@ -803,8 +881,6 @@ show_snapper()
 					d --textbox "$tmpfile" 0 0
 					;;
 				entries)
-					#read -r MACHINE_ID < /etc/machine-id
-					#update_entries jq "[.[]|select(.machineId==\"$MACHINE_ID\")|select(has(\"options\"))|select(.options|match(\"${subvol_prefix}/.snapshots/$n/snapshot\"))]"
 					update_entries_for_snapshot "$n"
 					show_entries "Entries for Snapshot $n"
 					;;
@@ -854,6 +930,7 @@ update_kernels()
 	stale_kernels=()
 	is_bootable=
 	find_kernels "$snapshot"
+	settle_entry_token "${snapshot}"
 	for kv in "${!found_kernels[@]}"; do
 		installed_kernels["/$entry_token/$kv/linux-${found_kernels[$kv]}"]=''
 	done
@@ -1067,6 +1144,7 @@ install_bootloader()
 		prefix="/.snapshots/${root_snapshot}/snapshot"
 	fi
 	local bootloader bldr_name blkpart drive partno
+	settle_entry_token "${snapshot}"
 
 	bootloader=$(find_bootloader "$snapshot")
 	bldr_name=$(bootloader_name "$snapshot")
@@ -1139,37 +1217,6 @@ install_bootloader()
 
 	# This action will require to update the PCR predictions
 	update_predictions=1
-}
-
-settle_entry_token()
-{
-	case "$arg_entry_token" in
-		"") [ -n "$entry_token" ] || entry_token="$machine_id" ;;
-		auto)
-			if [ -s '/etc/kernel/entry-token' ]; then
-				read -r entry_token < '/etc/kernel/entry-token'
-			else
-				entry_token="$machine_id"
-				# bootctl has more here in case the machine id
-				# is random falls back to trying IMAGE_ID and
-				# ID, only them machine id. We assume there is
-				# a valid machine-id
-			fi
-			;;
-		machine-id) entry_token="$machine_id" ;;
-		os-id)
-			# shellcheck disable=SC2154
-			entry_token="$os_release_ID"
-			[ -n "$entry_token" ] || err "Missing ID"
-			;;
-		os-image)
-			# shellcheck disable=SC2154
-			entry_token="$os_release_IMAGE_ID"
-			[ -n "$entry_token" ] || err "Missing IMAGE_ID"
-			;;
-		*) entry_token="$arg_entry_token" ;;
-	esac
-	return 0
 }
 
 hex_to_binary()
@@ -1548,12 +1595,6 @@ case "$1" in
 	*) err "unknown command $1" ;;
 esac
 
-for i in /etc/os-release /usr/lib/os-release; do
-	[ -f "$i" ] || continue
-	eval $(sed -ne '/^[A-Z_]\+=/s/^/os_release_/p' < "$i")
-	break
-done
-
 [ -n "$arg_esp_path" ] && export SYSTEMD_ESP_PATH="$arg_esp_path"
 
 # XXX: bootctl should have json output for that too
@@ -1566,32 +1607,27 @@ if [ "$(stat -f -c %T /)" = "btrfs" ] && [ -d /.snapshots ]; then
 	root_subvol=$(btrfs subvol show / 2>/dev/null|head -1)
 	subvol_prefix="${root_subvol%/.snapshots/*}"
 fi
-[ -s /etc/machine-id ] && read -r machine_id < /etc/machine-id
+root_snapshot=""
+if [ -n "$have_snapshots" ]; then
+	root_snapshot="${root_subvol#"${subvol_prefix}"/.snapshots/}"
+	root_snapshot="${root_snapshot%/snapshot}"
+fi
 
 if [ -n "$arg_esp_path" ] && [ "$boot_root" != "$arg_esp_path" ]; then
 	err "mismatch of esp path"
 fi
 [ -n "$arg_arch" ] && firmware_arch="$arg_arch"
-settle_entry_token
 
 [ -n "$boot_root" ] || err "No ESP detected. Legacy system?"
 [ -n "$root_uuid" ] || err "Can't determine root UUID"
 [ -n "$root_subvol" ] || [ -z "$have_snapshots" ] || err "Can't determine root subvolume"
 [ -n "$root_device" ] || err "Can't determine root device"
-[ -n "$entry_token" ] || err "No entry token. sd-boot not installed?"
 [ -n "$firmware_arch" ] || err "Can't determine firmware arch"
 case "$firmware_arch" in
 	x64) image=vmlinuz ;;
 	aa64) image=Image ;;
 	*) err "Unsupported architecture $firmware_arch" ;;
 esac
-
-root_snapshot=""
-
-if [ -n "$have_snapshots" ]; then
-	root_snapshot="${root_subvol#"${subvol_prefix}"/.snapshots/}"
-	root_snapshot="${root_snapshot%/snapshot}"
-fi
 
 # XXX: Unify both in /EFI/opensuse?
 if is_sdboot; then


### PR DESCRIPTION
This fixes an issue where the os-release file has been updated, but the old one is still used by sdbootutil to generate the new entries.
This should fix https://github.com/openSUSE/sdbootutil/issues/49

A quick test on tumbleweed worked