### PR TITLE
Add add-all-kernels-clean function

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -73,6 +73,10 @@ helpandquit()
 		add-all-kernels [SNAPSHOT]
 			   Create boot entries for all kernels in SNAPSHOT
 
+		mkinitrd [SNAPSHOT]
+			   Create boot entries for all kernels in SNAPSHOT,
+			   assumes --no-reuse-initrd to regenerate initrds
+
 		remove-kernel VERSION [SNAPSHOT]
 			   Remove boot entry for specified kernel
 
@@ -1417,7 +1421,7 @@ while true ; do
 done
 
 case "$1" in
-	install|needs-update|update|force-update|add-kernel|remove-kernel|set-default-snapshot|add-all-kernels|remove-all-kernels|is-installed|list-snapshots|list-entries|list-kernels|is-bootable|update-predictions) ;;
+	install|needs-update|update|force-update|add-kernel|remove-kernel|set-default-snapshot|add-all-kernels|mkinitrd|remove-all-kernels|is-installed|list-snapshots|list-entries|list-kernels|is-bootable|update-predictions) ;;
 	kernels|snapshots|entries|"") stty_size; interactive=1 ;;
 	*) err "unknown command $1" ;;
 esac
@@ -1469,6 +1473,9 @@ elif [ "$1" = "force-update" ]; then
 elif [ "$1" = "add-kernel" ]; then
 	install_kernel "${3:-$root_snapshot}" "$2"
 elif [ "$1" = "add-all-kernels" ]; then
+	install_all_kernels "${2:-$root_snapshot}"
+elif [ "$1" = "mkinitrd" ]; then
+	arg_no_reuse_initrd=1
 	install_all_kernels "${2:-$root_snapshot}"
 elif [ "$1" = "remove-kernel" ]; then
 	remove_kernel "${3:-$root_snapshot}" "$2"


### PR DESCRIPTION
This allows to easily add all kernels and regenerate the initrds for them
Fixes https://github.com/openSUSE/sdbootutil/issues/35

The name of the function is still quite long, but is easier to understand.
If a shorter name is preferred, this can be changed ofc :)

Command tested on Tumbleweed