### PR TITLE
Add bash completions

### DIFF
--- a/completions/bash_sdbootutil
+++ b/completions/bash_sdbootutil
@@ -1,0 +1,114 @@
+# shellcheck disable=SC2148
+shopt -s nullglob
+# shellcheck disable=SC2148
+err() {
+	:
+}
+
+_none() {
+	declare -ga result
+	result=()
+}
+
+_find_kernels()
+{
+	local fn kv
+	declare -ga result
+	result=()
+
+	for fn in /usr/lib/modules/*/"$image"; do
+		kv="${fn%/*}"
+		kv="${kv##*/}"
+		result+=("$kv")
+	done
+}
+
+_find_entry_ids()
+{
+	declare -ga result
+	result=()
+
+	mapfile -t result < <(bootctl list --json=short | jq -r '.[].id')
+}
+
+_arch_name() {
+	declare -ga result
+	result=("${!arch_image_map[@]}")
+}
+
+_image_name() {
+	declare -ga result
+	result=()
+	result=("${!arch_image_map[@]}")
+}
+
+_method() {
+	declare -ga result
+	result=()
+    for i in "tpm2" "tpm2+pin" "fido2" "password" "recovery-key"; do
+	    result+=("$i")
+    done
+}
+
+_sdbootutil_completion() {
+	eval "$(sdbootutil _print_bash_completion_data)"
+	local cur prev words cword image
+	COMPREPLY=()
+	_get_comp_words_by_ref -n : cur prev words cword
+
+	local command_found=0
+	eval_bootctl
+	set_image_name
+	define_commands
+
+	define_options
+	# shellcheck disable=SC2154
+	IFS=, read -r -a opts <<< "$opts_long"
+	local opts_with_dashes=()
+	for opt in "${opts[@]}"; do
+		opts_with_dashes+=("--${opt//:/}")
+	done
+
+	local i=0
+
+	for word in "${words[@]:1:$cword-1}"; do
+		if [ -n "${commands["$word"]+yes}" ]; then
+			command_found=1
+		fi
+		if [ " --arch " == " $word " ]; then
+			# shellcheck disable=SC2034
+			firmware_arch="${words[i+2]}"
+			set_image_name
+		fi
+		if [ " --image " == " $word " ]; then
+			image="${words[i+2]}"
+		fi
+		((i++))
+	done
+
+	# shellcheck disable=SC2154
+	local opt_arg_fun="${options_with_arg[${prev#--}]}"
+	if [ "${commands["$prev"]}" == "kernel" ]; then
+		_find_kernels
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${result[*]}" -- "$cur") )
+	elif [ "${commands["$prev"]}" == "id" ]; then
+		_find_entry_ids
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${result[*]}" -- "$cur") )
+	elif [ "$opt_arg_fun" == "_path" ]; then
+		# shellcheck disable=SC2207
+		COMPREPLY=($(compgen -d -- "$cur"))
+	elif [ "$opt_arg_fun" ]; then
+		eval "$opt_arg_fun"
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${result[*]}" -- "$cur") )
+	elif [[ $cur == -* ]] || [ $command_found -eq 1 ]; then
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${opts_with_dashes[*]}" -- "$cur") )
+	elif [ $command_found -eq 0 ]; then
+		# shellcheck disable=SC2207
+		COMPREPLY=( $(compgen -W "${!commands[*]}" -- "$cur") )
+	fi
+}
+complete -F _sdbootutil_completion sdbootutil

--- a/sdbootutil
+++ b/sdbootutil
@@ -2854,9 +2854,8 @@ if [ -z "$SYSTEMD_LOG_LEVEL" ] && [ -n "$verbose" ]; then
 fi
 
 define_commands
-if [ -z "$1" ] || [ "${commands["$1"]}" = "interactive" ]; then
-	stty_size
-	interactive=1
+if [ -z "$1" ]; then
+	helpandquit
 elif [ -z ${commands["$1"]+yes} ]; then
 	err "unknown command $1"
 fi

--- a/sdbootutil
+++ b/sdbootutil
@@ -2805,6 +2805,14 @@ bootloader_name()
 
 ####### main #######
 
+if [ "$1" = "_print_bash_completion_data" ]; then
+	declare -f set_image_name
+	declare -f eval_bootctl
+	declare -f define_commands
+	declare -f define_options
+	exit 0
+fi
+
 define_options
 getopt_tmp=$(getopt -o hc:v --long "$opts_long" -n "${0##*/}" -- "$@")
 eval set -- "$getopt_tmp"

--- a/sdbootutil
+++ b/sdbootutil
@@ -2718,6 +2718,12 @@ set_image_name() {
 	fi
 }
 
+eval_bootctl()
+{
+	# XXX: bootctl should have json output for that too
+	eval "$(bootctl 2>/dev/null | sed -ne 's/Firmware Arch: *\(\w\+\)/firmware_arch="\1"/p;s/ *token: *\(\w\+\)/entry_token="\1"/p;s, *\$BOOT: *\([^ ]\+\).*,boot_root="\1",p')"
+}
+
 bootloader_name()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
@@ -2777,9 +2783,7 @@ esac
 
 [ -n "$arg_esp_path" ] && export SYSTEMD_ESP_PATH="$arg_esp_path"
 
-# XXX: bootctl should have json output for that too
-# shellcheck disable=SC2016
-eval "$(bootctl 2>/dev/null | sed -ne 's/Firmware Arch: *\(\w\+\)/firmware_arch="\1"/p;s/ *token: *\(\w\+\)/entry_token="\1"/p;s, *\$BOOT: *\([^ ]\+\).*,boot_root="\1",p')"
+eval_bootctl
 read -r root_uuid root_device < <(findmnt / -v -r -n -o UUID,SOURCE)
 root_device_is_crypt=
 [ "$(lsblk --noheadings -o TYPE "$root_device")" = "crypt" ] && root_device_is_crypt=1

--- a/sdbootutil
+++ b/sdbootutil
@@ -2703,6 +2703,21 @@ unenroll()
 	done
 }
 
+set_image_name() {
+	[ -z "$image" ] || return
+
+	declare -gA arch_image_map=(
+		[x64]="vmlinuz"
+		[aa64]="Image"
+	)
+
+	if [ -n "${arch_image_map[$firmware_arch]}" ]; then
+		image="${arch_image_map[$firmware_arch]}"
+	else
+		err "Unsupported architecture $firmware_arch"
+	fi
+}
+
 bootloader_name()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
@@ -2796,11 +2811,7 @@ fi
 [ -n "$root_subvol" ] || [ -z "$have_snapshots" ] || err "Can't determine root subvolume"
 [ -n "$root_device" ] || err "Can't determine root device"
 [ -n "$firmware_arch" ] || err "Can't determine firmware arch"
-case "$firmware_arch" in
-	x64) image=vmlinuz ;;
-	aa64) image=Image ;;
-	*) err "Unsupported architecture $firmware_arch" ;;
-esac
+set_image_name
 
 # shellcheck disable=SC1091
 [ -e /etc/sysconfig/bootloader ] && . /etc/sysconfig/bootloader

--- a/sdbootutil
+++ b/sdbootutil
@@ -2756,6 +2756,42 @@ define_commands() {
 	)
 }
 
+define_options() {
+	declare -gA options_with_arg=(
+		[help]=""
+		[verbose]=""
+		[esp-path]="_path"
+		[entry-token]="_path"
+		[arch]="_arch_name"
+		[image]="_image_name"
+		[entry-keys]="_find_kernels"
+		[no-variables]=""
+		[no-reuse-initrd]=""
+		[no-random-seed]=""
+		[all]=""
+		[sync]=""
+		[portable]=""
+		[removable]=""
+		[only-default]=""
+		[default-snapshot]=""
+		[ask-key]=""
+		[ask-pin]=""
+		[ask-pw]=""
+		[method]="_method"
+		[signed-policy]=""
+		[pcr]="_none"
+	)
+	opts_long=""
+	for opt in "${!options_with_arg[@]}"; do
+		if [ "${options_with_arg[$opt]}" ]; then
+			opts_long+="${opt}:,"
+		else
+			opts_long+="${opt},"
+		fi
+	done
+	opts_long="${opts_long%,}"
+}
+
 bootloader_name()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
@@ -2769,8 +2805,9 @@ bootloader_name()
 
 ####### main #######
 
-getopttmp=$(getopt -o hc:v --long help,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,sync,portable,removable,only-default,default-snapshot,ask-key,ask-pin,ask-pw,method:,signed-policy,pcr: -n "${0##*/}" -- "$@")
-eval set -- "$getopttmp"
+define_options
+getopt_tmp=$(getopt -o hc:v --long "$opts_long" -n "${0##*/}" -- "$@")
+eval set -- "$getopt_tmp"
 
 while true ; do
 	case "$1" in

--- a/sdbootutil
+++ b/sdbootutil
@@ -2724,6 +2724,38 @@ eval_bootctl()
 	eval "$(bootctl 2>/dev/null | sed -ne 's/Firmware Arch: *\(\w\+\)/firmware_arch="\1"/p;s/ *token: *\(\w\+\)/entry_token="\1"/p;s, *\$BOOT: *\([^ ]\+\).*,boot_root="\1",p')"
 }
 
+define_commands() {
+	declare -gA commands=(
+		[install]=""
+		[needs-update]=""
+		[update]=""
+		[force-update]=""
+		[add-kernel]="kernel"
+		[remove-kernel]="kernel"
+		[set-default-snapshot]=""
+		[add-all-kernels]=""
+		[mkinitrd]=""
+		[remove-all-kernels]=""
+		[is-installed]=""
+		[list-snapshots]=""
+		[list-entries]=""
+		[list-kernels]=""
+		[list-devices]=""
+		[show-entry]="kernel"
+		[update-entry]="kernel"
+		[update-all-entries]=""
+		[is-bootable]=""
+		[set-default]="id"
+		[get-default]=""
+		[set-timeout]="seconds"
+		[get-timeout]=""
+		[enroll]=""
+		[unenroll]=""
+		[update-predictions]=""
+		[bootloader]=""
+	)
+}
+
 bootloader_name()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
@@ -2776,10 +2808,13 @@ if [ -z "$SYSTEMD_LOG_LEVEL" ] && [ -n "$verbose" ]; then
 	export SYSTEMD_LOG_LEVEL
 fi
 
-case "$1" in
-	install|needs-update|update|force-update|add-kernel|remove-kernel|set-default-snapshot|add-all-kernels|mkinitrd|remove-all-kernels|is-installed|list-snapshots|list-entries|list-kernels|list-devices|show-entry|update-entry|update-all-entries|is-bootable|set-default|get-default|set-timeout|get-timeout|enroll|unenroll|update-predictions|bootloader|"") ;;
-	*) err "unknown command $1" ;;
-esac
+define_commands
+if [ -z "$1" ] || [ "${commands["$1"]}" = "interactive" ]; then
+	stty_size
+	interactive=1
+elif [ -z ${commands["$1"]+yes} ]; then
+	err "unknown command $1"
+fi
 
 [ -n "$arg_esp_path" ] && export SYSTEMD_ESP_PATH="$arg_esp_path"
 

--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -94,6 +94,17 @@ JEOS module for full disk encryption enrollment. The module
 present the different options and delegate into sdbootutil-enroll
 service the effective enrollment.
 
+%package bash-completion
+Summary:        Bash completions for sdbootutil
+Requires:       sdbootutil >= %{version}-%{release}
+Requires:       bash
+Requires:       bash-completion
+
+%description bash-completion
+Bash completions script for sdbootutil.
+Allows the user to press TAB to see available commands,
+options and parameters.
+
 %prep
 %setup -q
 
@@ -123,6 +134,9 @@ install -D -m 755 10-%{name}.tukit %{buildroot}%{_prefix}/lib/tukit/plugins/10-%
 
 # kernel-install
 install -D -m 755 50-%{name}.install %{buildroot}%{_prefix}/lib/kernel/install.d/50-%{name}.install
+
+#bash completions
+install -D -m 755 completions/bash_sdbootutil %{buildroot}%{_datadir}/bash-completion/completions/sdbootutil
 
 # tmpfiles
 install -D -m 755 kernel-install-%{name}.conf \
@@ -194,5 +208,10 @@ sdbootutil update
 %{_datadir}/jeos-firstboot/modules/enroll
 %dir %{_unitdir}/jeos-firstboot.service.d
 %{_unitdir}/jeos-firstboot.service.d/jeos-firstboot-enroll-override.conf
+
+%files bash-completion
+%dir %{_datadir}/bash-completion
+%dir %{_datadir}/bash-completion/completions
+%{_datadir}/bash-completion/completions/sdbootutil
 
 %changelog


### PR DESCRIPTION
This will complete started commands and provide a list of possible commands and options.

Closes https://github.com/openSUSE/sdbootutil/issues/61

Unfortunately, we can't access the available snapshots, so the user still has to know which ones are available on his system. Equally, we can't enter snapshots to find kernel versions, so we recommend only the currently installed kernels.