### PR TITLE
Remove old kernels when no space is available

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -21,6 +21,8 @@ arg_no_variables=
 arg_no_reuse_initrd=
 arg_no_random_seed=
 have_snapshots=
+src_size_kb=
+declare -A pending_esp_files
 # for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 image=
 
@@ -330,6 +332,13 @@ update_entries_for_this_system()
 	update_entries jq "[.[]|select(has(\"options\"))|select(.options|match(\"root=UUID=$root_uuid\"))]"
 }
 
+find_conf_ids_by_kernel_version() {
+    local kernel_version="${1:?}"
+    local id_prefix="$entry_token-$kernel_version"
+	update_entries_for_this_system
+    jq -r --arg id_prefix "$id_prefix" '.[] | select(.id | startswith($id_prefix) and endswith(".conf")) | .id' < "$entryfile"
+}
+
 find_conf_file() {
 	local kernel_version="${1:?}"
 	local snapshot="$2"
@@ -400,6 +409,56 @@ remove_kernel()
 	update_predictions=1
 }
 
+remove_oldest_kernel()
+{
+	local snapshot="$1"
+	local root_snapshot="$2"
+	find_kernels "${snapshot}"
+	local snapshot_kernels=("${!found_kernels[@]}")
+	find_kernels "${root_snapshot}"
+	declare -A kernels=()
+	declare -a bootable_kernels
+	local id conf_files
+	for kernel in "${snapshot_kernels[@]}" "${!found_kernels[@]}"; do
+		kernels["$kernel"]=1
+	done
+
+	update_entries_for_this_system
+	while IFS= read -r id; do
+		if [[ ! $id == "$entry_token"* || ! $id == *.conf ]]; then
+			continue
+		fi
+		cleaned_id=${id#"$entry_token"-}
+		cleaned_id=${cleaned_id%.conf}
+		cleaned_id=${cleaned_id%-+([0-9]|-*[0-9])}
+
+		if [[ -n "$snapshot" ]]; then
+			cleaned_id=${cleaned_id%-*}
+		fi
+
+		bootable_kernels+=("$cleaned_id")
+	done < <(jq -r '.[].id' "$entryfile" | sort -Vu)
+
+	local oldest_removable_kernel=""
+	for kernel in "${bootable_kernels[@]}"; do
+		if [[ ! ${kernels[$kernel]+_} ]]; then
+			oldest_removable_kernel="$kernel"
+			break
+		fi
+	done
+
+	if [[ -z "$oldest_removable_kernel" ]]; then
+		log_info "Not enough disk space & no kernels to remove."
+		return 1
+	fi
+
+	conf_files=$(find_conf_ids_by_kernel_version "$oldest_removable_kernel")
+	while IFS= read -r id; do
+		bootctl unlink "$id"
+		log_info "Unlinked .conf file for ID: $id"
+	done <<< "$conf_files"
+}
+
 install_with_rollback()
 {
 	local src="${1:?}"
@@ -416,6 +475,49 @@ install_with_rollback()
 	install -p -m 0644 "$src" "$dst" || return "$?"
 	chown root:root "$dst" 2>/dev/null || :
 	log_info "installed $dst"
+}
+
+make_space_esp()
+{
+	local snapshot="$1"
+	local root_snapshot="$2"
+	local available_space_kb
+
+	if [ -d "$boot_root" ]; then
+		read -r available_space_bytes < <(findmnt -n -b -o AVAIL --target "$boot_root")
+		available_space_kb=$((available_space_bytes / 1024))
+	else
+		log_info "Directory doesn't exist: $boot_root"
+		return 1
+	fi
+
+	while [ "$available_space_kb" -lt "$src_size_kb" ]; do
+		log_info "Not enough space available in $boot_root"
+		remove_oldest_kernel "${snapshot}" "${root_snapshot}" || return "$?"
+		read -r available_space_bytes < <(findmnt -n -b -o AVAIL --target "$boot_root")
+		available_space_kb=$((available_space_bytes / 1024))
+	done
+
+	for src in "${!pending_esp_files[@]}"; do
+		dst=${pending_esp_files[$src]}
+		mkdir -p "$boot_root${dst%/*}"  2>/dev/null || return "$?"
+	done
+}
+
+add_pending_esp_file()
+{
+	local src="${1:?}"
+	local dst="${2:?}"
+
+	pending_esp_files["$src"]="$dst"
+	if [ -e "$dst" ] && cmp -s "$src" "$dst"; then
+		return 0
+	fi
+	read -r current_size_kb  _p < <(du -L "$src")
+	((src_size_kb+=current_size_kb))
+	if [ ! -d "$boot_root${dst%/*}" ]; then
+		((src_size_kb+=4))
+	fi
 }
 
 update_snapper()
@@ -514,12 +616,18 @@ reuse_initrd() {
 
 	if [ "$find_conf_status" -eq 0 ]; then
 		local k v
+		local i=0
 		while read -r k v; do
 			[ "$k" = 'initrd' ] || continue
 			log_info "found existing initrd $v"
-			dstinitrd+=("$v")
+			while [ -e "$tmpdir/initrd-$i" ]; do
+				((i++))
+			done
+			if [ -e "$boot_root$v" ]; then
+				ln -s "$boot_root$v" "$tmpdir/initrd-$i"
+			fi
 		done < "$conf"
-		[ -z "$dstinitrd" ] || return 0
+		[ ! -e "$tmpdir/initrd-0" ] || return 0
 	fi
 
 	return 1
@@ -566,20 +674,21 @@ install_kernel()
 	local subvol=""
 	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
 	local kernel_version="$2"
-	local dstinitrd=()
 	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
 	local initrddir="${subvol#"${subvol_prefix}"}/usr/lib/initrd"
+	src_size_kb=0
 	[ -n "$kernel_version" ] || err "Missing kernel version"
 	[ -e "$src" ] || err "Can't find $src"
 
-	calc_chksum "$src"
+	if [ -e "$src" ]; then
+		ln -s "$src" "$tmpdir/linux-0"
+	fi
+	calc_chksum "$tmpdir/linux-0"
 	settle_entry_token "${snapshot}"
 	local dst="/$entry_token/$kernel_version/linux-$chksum"
-
+	add_pending_esp_file "$tmpdir/linux-0" "$dst"
+	
 	local initrd="${src%/*}/initrd"
-
-	mkdir -p "$boot_root${dst%/*}"
-
 	if [ -e "$initrd" ]; then
 		ln -s "$initrd" "$tmpdir/initrd-0"
 	elif [ -d "$initrddir" ] && [ -x "/usr/bin/mkmoduleinitrd" ]; then
@@ -616,15 +725,6 @@ install_kernel()
 		break
 	done
 
-	if [ -z "$dstinitrd" ] && [ -e "$tmpdir/initrd-0" ]; then
-		i=0
-		while [ -e "$tmpdir/initrd-$i" ]; do
-			calc_chksum "$tmpdir/initrd-$i"
-			dstinitrd+=("${dst%/*}/initrd-$chksum")
-			((++i))
-		done
-	fi
-
 	title="${os_release_PRETTY_NAME:-Linux $kernel_version}"
 	# shellcheck disable=SC2154
 	sort_key="$os_release_ID"
@@ -646,41 +746,40 @@ install_kernel()
 	options    $boot_options
 	linux      $dst
 	EOF
-	for i in "${dstinitrd[@]}"; do
-		echo "initrd     $i" >> "$tmpdir/entry.conf"
+	local i=0
+	while [ -e "$tmpdir/initrd-$i" ]; do
+		calc_chksum "$tmpdir/initrd-$i"
+		add_pending_esp_file "$tmpdir/initrd-$i" "${dst%/*}/initrd-$chksum"
+		echo "initrd     ${dst%/*}/initrd-$chksum" >> "$tmpdir/entry.conf"
+		((++i))
 	done
+	local tries
+	if [ -f /etc/kernel/tries ]; then
+		read -r tries < /etc/kernel/tries
+	fi
+
+	if ! [[ "$tries" =~ ^[0-9]+$ ]]; then
+		tries=
+	fi
+	local loader_entry="/loader/entries/$entry_token-$kernel_version${snapshot:+-$snapshot}${tries:++$tries}.conf"
+	add_pending_esp_file "$tmpdir/entry.conf" "$loader_entry"
 
 	local failed=
-	if [ ! -e "$boot_root$dst" ]; then
-		install_with_rollback "$src" "$boot_root$dst" || failed=kernel
-	else
-		log_info "reusing $boot_root$dst"
-	fi
-	if [ -z "$failed" ] && [ -e "$tmpdir/initrd-0" ]; then
-		i=0
-		while [ -e "$tmpdir/initrd-$i" ]; do
-			if [ ! -e "$boot_root${dstinitrd[$i]}" ]; then
-				install_with_rollback "$tmpdir/initrd-$i" "$boot_root${dstinitrd[$i]}" || { failed=initrd; break; }
-				rm -f "$tmpdir/initrd-$i"
+	make_space_esp "${snapshot}" "${root_snapshot}" || failed="Not enough space on $boot_root"
+	for file_src in "${!pending_esp_files[@]}"; do
+		if [ -z "$failed" ]; then
+			local file_dst=${pending_esp_files[$file_src]}
+			if [ -e "$file_src" ] && [ -d "$boot_root${file_dst%/*}" ]; then
+				install_with_rollback "$file_src" "$boot_root$file_dst" || failed="$file_src to $file_dst"
+				rm -f "$file_src"
+			else
+				failed="missing file: $file_src to $file_dst"
 			fi
-			((++i))
-		done
-	fi
-	if [ -z "$failed" ]; then
-		local tries
-		if [ -f /etc/kernel/tries ]; then
-			read -r tries < /etc/kernel/tries
+		else
+			break;
 		fi
-
-		if ! [[ "$tries" =~ ^[0-9]+$ ]]; then
-			tries=
-		fi
-
-		loader_entry="$boot_root/loader/entries/$entry_token-$kernel_version${snapshot:+-$snapshot}${tries:++$tries}.conf"
-		install_with_rollback "$tmpdir/entry.conf" "$loader_entry" || failed="bootloader entry"
-		rm -f "$tmpdir/entry.conf"
-	fi
-	[ -z "$failed" ] || err "Failed to install $failed"
+	done
+	[ -z "$failed" ] || err "Failed to install: $failed"
 	reset_rollback
 
 	# This action will require to update the PCR predictions


### PR DESCRIPTION
This will clean up old kernels to free space on the ESP when a new kernel should be installed. Only kernels that are not installed in the to be installed snapshot and root snapshot (current snaphsot) might be removed

fixes https://github.com/openSUSE/sdbootutil/issues/26

Tested this on Tumbleweed