### PR TITLE
Revert "Remove GRUB2 package conflict"

### DIFF
--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -58,6 +58,9 @@ Plugin scripts for snapper to handle BLS config files
 %package rpm-scriptlets
 Summary:        Scripts to create boot entries on kernel updates
 Requires:       sdbootutil >= %{version}-%{release}
+# make sure to not replace scriptlets with nops on systems that
+# use grub2
+Conflicts:      grub2
 Conflicts:      suse-kernel-rpm-scriptlets
 Provides:       suse-kernel-rpm-scriptlets
 Obsoletes:      %{name}-filetriggers < %{version}


### PR DESCRIPTION
This reverts commit eaf8c97427224440fd0aea90789857ad05e38dbb.

We need to get rid of sdbootutil-rpm-scriptlets to avoid it taking prefernce over suse-module-tools-scriptlets