### PR TITLE
.spec - requires: dialog

### DIFF
--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -38,6 +38,7 @@ Requires:       systemd-boot
 Requires:       jq
 Requires:       sed
 Requires:       pcr-oracle
+Requires:       dialog
 # While systemd-pcrlock is in experimental
 Requires:       systemd-experimental
 Requires:       dracut-pcr-signature


### PR DESCRIPTION
We use dialog for the awesome TUI mode, but we don't make sure it's actually installed until this PR :)