### PR TITLE
Call regenerate-initrd-posttrans

### DIFF
--- a/10-sdbootutil.snapper
+++ b/10-sdbootutil.snapper
@@ -46,6 +46,10 @@ set_default_snapshot()
 	if is_transactional; then
 		/usr/bin/sdbootutil add-all-kernels "$num" || :
 		/usr/bin/sdbootutil update "$num" || :
+
+		if [ -e /usr/lib/module-init-tools/regenerate-initrd-posttrans ]; then
+			/usr/lib/module-init-tools/regenerate-initrd-posttrans
+		fi
 	fi
 
 	/usr/bin/sdbootutil set-default-snapshot "$num"

--- a/10-sdbootutil.tukit
+++ b/10-sdbootutil.tukit
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+shopt -s extglob nullglob
+set -e
+
+# check whether it's a transactional system
+is_transactional()
+{
+    [ "$(stat -f -c %T /etc)" = "overlayfs" ]
+}
+
+callExt_post()
+{
+    path="$1"
+
+    if [ -e "$path"/run/regenerate-initrd ]; then
+	cp -a "$path"/run/regenerate-initrd /run
+    fi
+}
+
+h()
+{
+    echo "Available commands:"
+    echo "${!commands[@]}"
+}
+
+declare -A commands
+
+commands['callExt-post']=callExt_post
+commands['help']=h
+
+cmd="$1"
+shift
+[ -n "$cmd" ] || cmd=help
+if [ "${#commands[$cmd]}" -gt 0 ]; then
+    ${commands[$cmd]} "$@"
+fi

--- a/sdbootutil.spec
+++ b/sdbootutil.spec
@@ -44,6 +44,7 @@ Requires:       systemd-experimental
 Requires:       dracut-pcr-signature
 Supplements:    (systemd-boot and shim)
 Requires:       (%{name}-snapper if (snapper and btrfsprogs))
+Requires:       (%{name}-tukit if read-only-root-fs)
 ExclusiveArch:  aarch64 ppc64le riscv64 x86_64
 
 %description
@@ -58,6 +59,15 @@ Requires:       snapper
 
 %description snapper
 Plugin scripts for snapper to handle BLS config files
+
+%package tukit
+Summary:        plugin script for tukit
+Requires:       %{name} = %{version}
+Requires:       sdbootutil >= %{version}-%{release}
+Requires:       tukit
+
+%description tukit
+Plugin scripts for tukit to handle BLS config files
 
 %package rpm-scriptlets
 Summary:        Scripts to create boot entries on kernel updates
@@ -114,6 +124,12 @@ for i in 10-sdbootutil.snapper; do
   install -m 755 $i %{buildroot}%{_prefix}/lib/snapper/plugins/$i
 done
 
+# tukit
+install -d -m755 %{buildroot}%{_prefix}/lib/tukit/plugins
+for i in 10-sdbootutil.tukit; do
+  install -m 755 $i %{buildroot}%{_prefix}/lib/tukit/plugins/$i
+done
+
 # kernel-install
 install -d -m755 %{buildroot}%{_prefix}/lib/kernel/install.d
 for i in 50-sdbootutil.install; do
@@ -151,6 +167,11 @@ sdbootutil update
 %dir %{_prefix}/lib/snapper
 %dir %{_prefix}/lib/snapper/plugins
 %{_prefix}/lib/snapper/plugins/*
+
+%files tukit
+%dir %{_prefix}/lib/tukit
+%dir %{_prefix}/lib/tukit/plugins
+%{_prefix}/lib/tukit/plugins/*
 
 %files kernel-install
 %dir %{_prefix}/lib/kernel


### PR DESCRIPTION
In MicroOS the initrd needs to be generated at the end of the transaction.  This commit call the regenerate script from suse-module-tools from the set_default_snapshot.

The renegerate script detect if the transaction is ongoing, and will avoid the call to sdbootutil, but if the transaction is done (for example, when called from the snapper hook) it will correctly generate a new initrd.

Note that regenerate-initrd-posttrans will move the file mark to /dev/shm if it is in a transactional system, because /run does not escape the transaction.