### PR TITLE
Turn off colors when the shell it not interactive

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -28,7 +28,12 @@ image=
 
 color_red=
 color_end=
-if [ "$SYSTEMD_COLORS" != "false" ] && [ "$SYSTEMD_COLORS" != "0" ]; then
+# The shell is interactive and the colors haven't been disabled forcefully
+# or the shell is not interactive but the colors have been forcefully enabled
+if { [[ "$-" == *i* ]] \
+    && [ "$SYSTEMD_COLORS" != "false" ] && [ "$SYSTEMD_COLORS" != "0" ]; } \
+    || [[ "$-" != *i* ]] \
+    && { [ "$SYSTEMD_COLORS" = "true" ] || [ "$SYSTEMD_COLORS" = "1" ]; }; then
 	color_red="\e[31m"
 	color_green="\e[32m"
 	color_yellow="\e[33m"


### PR DESCRIPTION
Allow overide by using SYSTEMD_COLORS.