### PR TITLE
Enroll a new recovery key

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -2017,7 +2017,7 @@ generate_tpm2_predictions_pcrlock()
 	local pin
 	local extra=()
 	local keyid
-	keyid="$(keyctl id %user:cryptenroll 2> /dev/null)" || true
+	keyid="$(keyctl id %user:recoverypin 2> /dev/null)" || true
 	if [ -n "$arg_ask_pin_or_pw" ]; then
 		read -r -s -p "Recovery PIN: " pin
 		extra=("--recovery-pin=yes")
@@ -2056,9 +2056,9 @@ generate_tpm2_predictions_pcrlock()
 
 				# Add the generated recovery PIN to the kernel keyring, so that it is available to
 				# sdbootutil --method=recovery-key
-				echo -n "$pin" | keyctl padd user pin @u > /dev/null
+				echo -n "$pin" | keyctl padd user recoverykey @u > /dev/null
 				# Make the key expire after 2 minutes
-				keyctl timeout %user:pin 120
+				keyctl timeout %user:recoverykey 120
 		fi
 	fi
 
@@ -2509,7 +2509,9 @@ enroll()
 		fi
 	fi
 
-	if [ "$arg_method" == "recovery-key" ] && tmp_key_id=$(keyctl id %user:pin); then
+	# When calling --method=tpm2 and a recovery PIN is generated, it is also set in
+	# %user:recoverykey to be used as recovery key by --method=recovery-key
+	if [ "$arg_method" == "recovery-key" ] && tmp_key_id=$(keyctl id %user:recoverykey); then
 		recovery_key_id="$tmp_key_id"
 	fi
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -31,7 +31,6 @@ have_snapshots=
 # for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 image=
 recovery_key_id=
-tpm2_policy_enrolled=
 unlock_extra_arg=
 
 color_red=
@@ -2020,6 +2019,10 @@ generate_tpm2_predictions_pcrlock()
 	local pin
 	local extra=()
 	local keyid
+	local tpm2_policy_enrolled
+	if [ "$arg_method" = "tpm2" ] || [ "$arg_method" = "tpm2+pin" ]; then
+		tpm2_policy_enrolled=1
+	fi
 	keyid="$(keyctl id %user:recoverypin 2> /dev/null)" || true
 	if [ -n "$arg_ask_pin_or_pw" ]; then
 		read -r -s -p "Recovery PIN: " pin
@@ -2055,7 +2058,10 @@ generate_tpm2_predictions_pcrlock()
 				local split
 				IFS=":" read -r -a split <<< "$output"
 				pin="${split[1]}"
-				echo "$pin" | qrencode -t utf8i
+				# Trim the output
+				pin="${pin## }"
+				pin="${pin%% }"
+				qrencode -t utf8i "$pin"
 
 				# Add the generated recovery PIN to the kernel keyring, so that it is available to
 				# sdbootutil --method=recovery-key
@@ -2300,15 +2306,18 @@ enroll_pcrlock()
 	fi
 
 	# Note that the PCRs are now not stored in the LUKS2 header
-	NEWPIN="$tpm_pin" systemd-cryptenroll \
+	if NEWPIN="$tpm_pin" systemd-cryptenroll \
 		--wipe-slot=tpm2 \
 		--tpm2-device=auto \
 		"${extra_args[@]}" \
 		--tpm2-pcrlock=/var/lib/systemd/pcrlock.json \
-		"$dev"
-	# cryptenroll exits successfully even if the token was not enrolled
-	# Manually check if the device has a tpm2 slot enrolled
-	systemd-cryptenroll "$dev" | grep "tpm2"
+		"$dev"; then
+		# cryptenroll exits successfully even if the token was not enrolled
+		# Manually check if the device has a tpm2 slot enrolled
+		systemd-cryptenroll "$dev" | grep -q "tpm2"
+	else
+		return 1
+	fi
 }
 
 enroll_pcroracle()
@@ -2334,16 +2343,19 @@ enroll_pcroracle()
 	fi
 
 	# Note that the PCRs are now not stored in the LUKS2 header
-	NEWPIN="$tpm_pin" systemd-cryptenroll \
+	if NEWPIN="$tpm_pin" systemd-cryptenroll \
 		--wipe-slot=tpm2 \
 		--tpm2-device=auto \
 		"${extra_args[@]}" \
 		--tpm2-public-key=/etc/systemd/tpm2-pcr-public-key.pem \
 		--tpm2-public-key-pcrs="${FDE_SEAL_PCR_LIST}" \
-		"$dev"
-	# cryptenroll exits successfully even if the token was not enrolled
-	# Manually check if the device has a tpm2 slot enrolled
-	systemd-cryptenroll "$dev" | grep "tpm2"
+		"$dev"; then
+		# cryptenroll exits successfully even if the token was not enrolled
+		# Manually check if the device has a tpm2 slot enrolled
+		systemd-cryptenroll "$dev" | grep -q "tpm2"
+	else
+		return 1
+	fi
 }
 
 enroll_fido2()
@@ -2435,7 +2447,6 @@ enroll_device()
 
 	case "$arg_method" in
 		"tpm2"|"tpm2+pin")
-			tpm2_policy_enrolled=1
 			if [ -z "$arg_signed_policy" ] && have_pcrlock; then
 				enroll_pcrlock "$dev" "$pin_or_pw" || {
 					echo "Enrollment with systemd-pcrlock failed"
@@ -2606,7 +2617,7 @@ unenroll_device()
 				"$dev"
 			;;
 
-		"recovery_key")
+		"recovery-key")
 			systemd-cryptenroll \
 				--wipe-slot=recovery \
 				"$dev"

--- a/sdbootutil
+++ b/sdbootutil
@@ -28,6 +28,7 @@ arg_signed_policy=
 have_snapshots=
 # for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 image=
+recovery_key_id=
 
 color_red=
 color_end=
@@ -93,7 +94,7 @@ helpandquit()
 		  --ask-pin		Ask recovery PIN for re-enrollment
 					Ask TPM2 PIN when initial enrollment
 		  --ask-pw		Ask password when initial enrollment
-		  --method		"tpm2", "tpm2+pin", "fido2", "password"
+		  --method		"tpm2", "tpm2+pin", "fido2", "password", "recovery-key"
 		  --signed-policy	Use signed policy for TPM2 enrollment
 		  -v, --verbose		More verbose output
 		  -h, --help		This screen
@@ -2321,6 +2322,48 @@ enroll_password()
 	NEWPASSWORD="$pw" systemd-cryptenroll --wipe-slot=password --password "$dev"
 }
 
+enroll_recovery_key()
+{
+	local dev="$1"
+
+	echo "Enrolling with recovery key: $dev"
+
+	local recovery_key
+	# This function will be called for every device. Let systemd generate a secure recovery key
+	# only the first time. Unlock the LUKS2 header by using the TPM2 slot
+	if [ -z "$recovery_key_id" ]; then
+			if recovery_key=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key --unlock-tpm2-device=auto "$dev"); then
+			echo "Recovery key: $recovery_key"
+
+			if [ -x /usr/bin/qrencode ]; then
+					echo "You can also scan it with your mobile phone:"
+					echo "$recovery_key" | qrencode -t utf8i
+			fi
+
+			# Add the generated recovery key to the kernel keyring, so that it is available to
+			# sdbootutil --method=tpm2
+			read -r recovery_key_id < <(echo -n "$recovery_key" | keyctl padd user cryptenroll @u)
+		else
+			echo "Unable to generate a recovery key for $dev"
+		fi
+	else
+		# A recovery key has already been generated, use it for all the devices
+		recovery_key="$(keyctl pipe "$recovery_key_id")"
+		if ! tmp_rk=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key --unlock-tpm2-device=auto "$dev"); then
+			echo "Unable to access device $dev"
+			return 1
+		fi
+		# systemd-cryptenroll always generated a random recovery key, but we want $recovery_key
+		# Replace it by using cryptsetup
+		read -r -a split < <(systemd-cryptenroll /dev/vda3 | grep recovery)
+		keyslot="${split[0]}"
+		# cryptsetup can only read the new passphrase from a keyfile
+		echo -n "$recovery_key" > recovery_key
+		cryptsetup luksChangeKey --key-slot "$keyslot" "$dev" recovery_key < <(echo "$tmp_rk")
+		rm recovery_key
+	fi
+}
+
 enroll_device()
 {
 	local dev="$1"
@@ -2351,6 +2394,10 @@ enroll_device()
 
 		"password")
 			enroll_password "$dev" "$pin_or_pw"
+			;;
+
+		"recovery-key")
+			enroll_recovery_key "$dev"
 			;;
 
 		*)
@@ -2485,6 +2532,12 @@ unenroll_device()
 		"password")
 			systemd-cryptenroll \
 				--wipe-slot=password \
+				"$dev"
+			;;
+
+		"recovery_key")
+			systemd-cryptenroll \
+				--wipe-slot=recovery \
 				"$dev"
 			;;
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -26,11 +26,13 @@ arg_ask_pin_or_pw=
 arg_method=
 arg_signed_policy=
 arg_generate_pin=
+arg_unlock=
 have_snapshots=
 # for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 image=
 recovery_key_id=
 tpm2_policy_enrolled=
+unlock_extra_arg=
 
 color_red=
 color_end=
@@ -99,6 +101,7 @@ helpandquit()
 		  --method		"tpm2", "tpm2+pin", "fido2", "password", "recovery-key"
 		  --signed-policy	Use signed policy for TPM2 enrollment
 		  --generate-pin	Generate a random TPM2 recovery pin for TPM2 enrollment
+		  --unlock		"fido2", "tpm2", "passphrase", "recovery"
 		  -v, --verbose		More verbose output
 		  -h, --help		This screen
 
@@ -2239,6 +2242,41 @@ generate_rsa_key()
 		store-public-key
 }
 
+unlock_method()
+{
+	local dev="$1"
+	local enrollment="$2"
+	case "$arg_unlock" in
+		"tpm2")
+			unlock_extra_arg="--unlock-tpm2-device=auto"
+			;;
+		"fido2")
+			unlock_extra_arg="--unlock-fido2-device=auto"
+			;;
+		"passphrase"|"recovery-key")
+			# The passphrase in this case should be set in the %user:cryptenroll key
+			# If it has not been set, systemd will ask it to the user
+			;;
+		"auto"|*)
+			local slots
+			if ! slots=$(systemd-cryptenroll "$dev"); then
+				echo "Unable to get current slots for device $dev"
+				return 1
+			fi
+			# Do not use TPM2 slot for enrolling TPM2
+			if [ "$enrollment" != "tpm2" ] && echo "$slots" | grep -q tpm2; then
+				echo "Unlocking using TPM2"
+				unlock_extra_arg="--unlock-tpm2-device=auto"
+			# Same for FIDO2
+			elif [ "$enrollment" != "fido2" ] && echo "$slots" | grep -q fido2; then
+				echo "Unlocking using FIDO2"
+				unlock_extra_arg="--unlock-fido2-device=auto"
+			fi
+			# Use %user:cryptenroll or let systemd-cryptenroll ask the passphrase
+			;;
+	esac
+}
+
 enroll_pcrlock()
 {
 	local dev="$1"
@@ -2256,14 +2294,14 @@ enroll_pcrlock()
 		warn "Could not find /var/lib/systemd/pcrlock.json"
 	fi
 
-	# The password is read from "cryptenroll" kernel keyring
-	# XXX: Wipe is separated by now (possible systemd bug)
-	systemd-cryptenroll \
-		--wipe-slot=tpm2 \
-		"$dev"
+	unlock_method "$dev" "tpm2"
+	if [ -n "$unlock_extra_arg" ]; then
+		extra_args+=("$unlock_extra_arg")
+	fi
 
 	# Note that the PCRs are now not stored in the LUKS2 header
 	NEWPIN="$tpm_pin" systemd-cryptenroll \
+		--wipe-slot=tpm2 \
 		--tpm2-device=auto \
 		"${extra_args[@]}" \
 		--tpm2-pcrlock=/var/lib/systemd/pcrlock.json \
@@ -2290,14 +2328,14 @@ enroll_pcroracle()
 		warn "Could not find /etc/systemd/tpm2-pcr-signature.json"
 	fi
 
-	# The password is read from "cryptenroll" kernel keyring
-	# XXX: Wipe is separated by now (possible systemd bug)
-	systemd-cryptenroll \
-		--wipe-slot=tpm2 \
-		"$dev"
+	unlock_method "$dev" "tpm2"
+	if [ -n "$unlock_extra_arg" ]; then
+		extra_args+=("$unlock_extra_arg")
+	fi
 
 	# Note that the PCRs are now not stored in the LUKS2 header
 	NEWPIN="$tpm_pin" systemd-cryptenroll \
+		--wipe-slot=tpm2 \
 		--tpm2-device=auto \
 		"${extra_args[@]}" \
 		--tpm2-public-key=/etc/systemd/tpm2-pcr-public-key.pem \
@@ -2314,14 +2352,12 @@ enroll_fido2()
 
 	echo "Enrolling with FIDO2: $dev"
 
-	# The password is read from "cryptenroll" kernel keyring
-	# XXX: Wipe is separated by now (possible systemd bug)
-	systemd-cryptenroll \
-		--wipe-slot=fido2 \
-		"$dev"
+	unlock_method "$dev" "fido2"
+	if [ -n "$unlock_extra_arg" ]; then
+		extra_args+=("$unlock_extra_arg")
+	fi
 
-	# The password is read from "cryptenroll" kernel keyring
-	systemd-cryptenroll --fido2-device=auto "$dev"
+	systemd-cryptenroll --wipe-slot=fido2 --fido2-device=auto "$dev"
 }
 
 enroll_password()
@@ -2331,7 +2367,11 @@ enroll_password()
 
 	echo "Enrolling with password: $dev"
 
-	# The password is read from "cryptenroll" kernel keyring
+	unlock_method "$dev" "password"
+	if [ -n "$unlock_extra_arg" ]; then
+		extra_args+=("$unlock_extra_arg")
+	fi
+
 	NEWPASSWORD="$pw" systemd-cryptenroll --wipe-slot=password --password "$dev"
 }
 
@@ -2341,12 +2381,18 @@ enroll_recovery_key()
 
 	echo "Enrolling with recovery key: $dev"
 
+	local extra_args
+	unlock_method "$dev" "recovery-key"
+	if [ -n "$unlock_extra_arg" ]; then
+		extra_args="$unlock_extra_arg"
+	fi
+
 	local recovery_key
 	# This function will be called for every device. Let systemd generate a secure recovery key
 	# only the first time and if there is no recovery pin selected (%user:pin or %user:cryptenroll).
 	# Unlock the LUKS2 header by using the TPM2 slot
 	if [ -z "$recovery_key_id" ]; then
-			if recovery_key=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key --unlock-tpm2-device=auto "$dev"); then
+		if recovery_key=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key "${extra_args[@]}" "$dev"); then
 			echo "Recovery key: $recovery_key"
 
 			if [ -x /usr/bin/qrencode ]; then
@@ -2367,7 +2413,7 @@ enroll_recovery_key()
 	else
 		# A recovery key has already been generated, use it for all the devices
 		recovery_key="$(keyctl pipe "$recovery_key_id")"
-		if ! tmp_rk=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key --unlock-tpm2-device=auto "$dev"); then
+		if ! tmp_rk=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key "${extra_args[@]}" "$dev"); then
 			echo "Unable to access device $dev"
 			return 1
 		fi
@@ -2643,7 +2689,7 @@ main_menu()
 
 ####### main #######
 
-getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy,generate-pin -n "${0##*/}" -- "$@")
+getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy,generate-pin,unlock: -n "${0##*/}" -- "$@")
 eval set -- "$getopttmp"
 
 while true ; do
@@ -2667,6 +2713,7 @@ while true ; do
 		--method) arg_method="$2"; shift 2 ;;
 		--signed-policy) arg_signed_policy=1; shift ;;
 		--generate-pin) arg_generate_pin=1; shift ;;
+		--unlock) arg_unlock="$2"; shift 2 ;;
 		--) shift ; break ;;
 		*) echo "Internal error!" ; exit 1 ;;
 	esac

--- a/sdbootutil
+++ b/sdbootutil
@@ -25,10 +25,12 @@ arg_default_snapshot=
 arg_ask_pin_or_pw=
 arg_method=
 arg_signed_policy=
+arg_generate_pin=
 have_snapshots=
 # for x in vmlinuz image vmlinux linux bzImage uImage Image zImage; do
 image=
 recovery_key_id=
+tpm2_policy_enrolled=
 
 color_red=
 color_end=
@@ -96,6 +98,7 @@ helpandquit()
 		  --ask-pw		Ask password when initial enrollment
 		  --method		"tpm2", "tpm2+pin", "fido2", "password", "recovery-key"
 		  --signed-policy	Use signed policy for TPM2 enrollment
+		  --generate-pin	Generate a random TPM2 recovery pin for TPM2 enrollment
 		  -v, --verbose		More verbose output
 		  -h, --help		This screen
 
@@ -2018,13 +2021,16 @@ generate_tpm2_predictions_pcrlock()
 	if [ -n "$arg_ask_pin_or_pw" ]; then
 		read -r -s -p "Recovery PIN: " pin
 		extra=("--recovery-pin=yes")
+	elif [ -n "$arg_generate_pin" ]; then
+		extra=("--recovery-pin=show")
 	elif [ -n "$PIN" ]; then
 		pin="$PIN"
 		extra=("--recovery-pin=yes")
 	elif [ -n "$keyid" ]; then
 		pin="$(keyctl pipe "$keyid")"
 		extra=("--recovery-pin=yes")
-	else
+	# During the TPM2 enrollment (not when update-predictions is called by itself or by other commands)
+	elif [ -n "$tpm2_policy_enrolled" ]; then
 		# No PIN was provided, systemd-pcrlock will generate one
 		# Add this argument to show it
 		extra=("--recovery-pin=show")
@@ -2038,14 +2044,21 @@ generate_tpm2_predictions_pcrlock()
 		else
 			echo "Provided PIN incorrect or TPM2 locked after too many retries"
 		fi
-	elif [ -z "$pin" ]; then
+	elif [ -z "$pin" ] && [ -n "$tpm2_policy_enrolled" ]; then
 		if ! echo "$output" | grep "recovery PIN"; then
 			echo "Unable to find the generated recovery PIN"
 		elif [ -x /usr/bin/qrencode ]; then
 				echo "You can also scan it with your mobile phone:"
 				local split
 				IFS=":" read -r -a split <<< "$output"
-				echo "${split[1]}" | qrencode -t utf8i
+				pin="${split[1]}"
+				echo "$pin" | qrencode -t utf8i
+
+				# Add the generated recovery PIN to the kernel keyring, so that it is available to
+				# sdbootutil --method=recovery-key
+				echo -n "$pin" | keyctl padd user pin @u > /dev/null
+				# Make the key expire after 2 minutes
+				keyctl timeout %user:pin 120
 		fi
 	fi
 
@@ -2330,7 +2343,8 @@ enroll_recovery_key()
 
 	local recovery_key
 	# This function will be called for every device. Let systemd generate a secure recovery key
-	# only the first time. Unlock the LUKS2 header by using the TPM2 slot
+	# only the first time and if there is no recovery pin selected (%user:pin or %user:cryptenroll).
+	# Unlock the LUKS2 header by using the TPM2 slot
 	if [ -z "$recovery_key_id" ]; then
 			if recovery_key=$(systemd-cryptenroll --wipe-slot=recovery --recovery-key --unlock-tpm2-device=auto "$dev"); then
 			echo "Recovery key: $recovery_key"
@@ -2341,8 +2355,12 @@ enroll_recovery_key()
 			fi
 
 			# Add the generated recovery key to the kernel keyring, so that it is available to
-			# sdbootutil --method=tpm2
+			# systemd-cryptenroll
 			read -r recovery_key_id < <(echo -n "$recovery_key" | keyctl padd user cryptenroll @u)
+			keyctl timeout %user:cryptenroll 120
+			# And to --method=tpm2
+			read -r recovery_key_id < <(echo -n "$recovery_key" | keyctl padd user recoverypin @u)
+			keyctl timeout %user:recoverypin 120
 		else
 			echo "Unable to generate a recovery key for $dev"
 		fi
@@ -2353,13 +2371,13 @@ enroll_recovery_key()
 			echo "Unable to access device $dev"
 			return 1
 		fi
-		# systemd-cryptenroll always generated a random recovery key, but we want $recovery_key
+		# systemd-cryptenroll always generates a random recovery key, but we want $recovery_key
 		# Replace it by using cryptsetup
 		read -r -a split < <(systemd-cryptenroll /dev/vda3 | grep recovery)
 		keyslot="${split[0]}"
 		# cryptsetup can only read the new passphrase from a keyfile
 		echo -n "$recovery_key" > recovery_key
-		cryptsetup luksChangeKey --key-slot "$keyslot" "$dev" recovery_key < <(echo "$tmp_rk")
+		cryptsetup luksChangeKey --key-slot "$keyslot" "$dev" recovery_key <<<"$tmp_rk"
 		rm recovery_key
 	fi
 }
@@ -2371,6 +2389,7 @@ enroll_device()
 
 	case "$arg_method" in
 		"tpm2"|"tpm2+pin")
+			tpm2_policy_enrolled=1
 			if [ -z "$arg_signed_policy" ] && have_pcrlock; then
 				enroll_pcrlock "$dev" "$pin_or_pw" || {
 					echo "Enrollment with systemd-pcrlock failed"
@@ -2488,6 +2507,10 @@ enroll()
 		else
 			err "Use %u:pw, PW or --ask-pw to provide the password"
 		fi
+	fi
+
+	if [ "$arg_method" == "recovery-key" ] && tmp_key_id=$(keyctl id %user:pin); then
+		recovery_key_id="$tmp_key_id"
 	fi
 
 	for dev in "${luks2_devices[@]}"; do
@@ -2618,7 +2641,7 @@ main_menu()
 
 ####### main #######
 
-getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy -n "${0##*/}" -- "$@")
+getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy,generate-pin -n "${0##*/}" -- "$@")
 eval set -- "$getopttmp"
 
 while true ; do
@@ -2641,6 +2664,7 @@ while true ; do
 		--ask-pin|--ask-pw) arg_ask_pin_or_pw=1; shift ;;
 		--method) arg_method="$2"; shift 2 ;;
 		--signed-policy) arg_signed_policy=1; shift ;;
+		--generate-pin) arg_generate_pin=1; shift ;;
 		--) shift ; break ;;
 		*) echo "Internal error!" ; exit 1 ;;
 	esac


### PR DESCRIPTION
Add a method to enroll a new recovery key.  The only things missing are reading the key from `systemd-cryptenroll --recovery-key` and it should be ready and testing the command.