### PR TITLE
Changes in the bootloader detector and installer

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -1506,7 +1506,8 @@ install_bootloader()
 	fi
 
 	# Create boot menu entry if it does not exist
-	[ -n "$arg_no_variables" ] || [ -n "$arg_portable" ] || efibootmgr | grep -q 'Boot.*openSUSE Boot Manager' || efibootmgr -q --create --disk "$drive" --part "$partno" --label "openSUSE Boot Manager" --loader "$entry" || true
+	local escaped_entry="${entry//\//\\\\}"
+	[ -n "$arg_no_variables" ] || [ -n "$arg_portable" ] || efibootmgr | grep -q "Boot.*openSUSE Boot Manager.*${escaped_entry}" || efibootmgr -q --create --disk "$drive" --part "$partno" --label "openSUSE Boot Manager ($bldr_name)" --loader "$entry" || true
 
 	# Make it the first option
 	if [ -z "$arg_no_variables" ] && [ -z "$arg_portable" ]; then
@@ -1515,11 +1516,11 @@ install_bootloader()
 		boot_order="${boot_order#BootOrder: }"
 
 		local boot_entry
-		boot_entry="$(efibootmgr | grep 'Boot.*openSUSE Boot Manager')"
+		boot_entry="$(efibootmgr | grep "Boot.*openSUSE Boot Manager.*${escaped_entry}")"
 		boot_entry="${boot_entry%\* *}"
 		boot_entry="${boot_entry#Boot}"
 
-		efibootmgr -D -o "$boot_entry,$boot_order" || true
+		efibootmgr -q -D -o "$boot_entry,$boot_order" || true
 	fi
 
 	# This action will require to update the PCR predictions

--- a/sdbootutil
+++ b/sdbootutil
@@ -1508,6 +1508,20 @@ install_bootloader()
 	# Create boot menu entry if it does not exist
 	[ -n "$arg_no_variables" ] || [ -n "$arg_portable" ] || efibootmgr | grep -q 'Boot.*openSUSE Boot Manager' || efibootmgr -q --create --disk "$drive" --part "$partno" --label "openSUSE Boot Manager" --loader "$entry" || true
 
+	# Make it the first option
+	if [ -z "$arg_no_variables" ] && [ -z "$arg_portable" ]; then
+		local boot_order
+		boot_order="$(efibootmgr | grep BootOrder)"
+		boot_order="${boot_order#BootOrder: }"
+
+		local boot_entry
+		boot_entry="$(efibootmgr | grep 'Boot.*openSUSE Boot Manager')"
+		boot_entry="${boot_entry%\* *}"
+		boot_entry="${boot_entry#Boot}"
+
+		efibootmgr -D -o "$boot_entry,$boot_order" || true
+	fi
+
 	# This action will require to update the PCR predictions
 	update_predictions=1
 }

--- a/sdbootutil
+++ b/sdbootutil
@@ -219,21 +219,21 @@ warn()
 
 is_sdboot()
 {
-	# If systemd-boot and grub2 are co-installed, we favor grub2
-	# in the detection
-	local sdboot grub2
+	# If systemd-boot and grub2-bls are co-installed, we favor
+	# grub2-bls in the detection
+	local sdboot grub2_bls
 	sdboot="$(find_sdboot "${1-$root_snapshot}")"
-	grub2="$(find_grub2 "${1-$root_snapshot}")"
-	[ -e "$sdboot" ] && [ ! -e "$grub2" ]
+	grub2_bls="$(find_grub2_bls "${1-$root_snapshot}")"
+	[ -e "$sdboot" ] && [ ! -e "$grub2_bls" ]
 }
 
-is_grub2()
+is_grub2_bls()
 {
-	# If systemd-boot and grub2 are co-installed, we favor grub2
-	# in the detection
-	local grub2
-	grub2="$(find_grub2 "${1-$root_snapshot}")"
-	[ -e "$grub2" ]
+	# If systemd-boot and grub2-bls are co-installed, we favor
+	# grub2-bls in the detection
+	local grub2_bls
+	grub2_bls="$(find_grub2_bls "${1-$root_snapshot}")"
+	[ -e "$grub2_bls" ]
 }
 
 reset_rollback()
@@ -400,7 +400,7 @@ entry_conf_file()
 	local prefix=""
 	local subvol=""
 	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
-	if ! is_transactional && is_grub2; then
+	if ! is_transactional && is_grub2_bls; then
 		if ! subvol_is_ro "$subvol"; then
 			prefix="system"
 		else
@@ -1102,7 +1102,8 @@ update_entry()
 	local id
 	id="$(entry_conf_file "$kernel_version" "$snapshot")"
 
-	local conf="$(find_conf_file "$kernel_version" "$snapshot")"
+	local conf
+	conf="$(find_conf_file "$kernel_version" "$snapshot")"
 	[ -f "$conf" ] || return 0
 
 	echo "Updating $id"
@@ -1398,22 +1399,22 @@ find_sdboot()
 	echo "$sdboot"
 }
 
-find_grub2()
+find_grub2_bls()
 {
-	local grub2
+	local grub2_bls
 	# The old grub.efi will contain the BLS patches, but we cannot
 	# use it because we also dropped the process of creating the
 	# configuration file and installing bli.mod
-	grub2="/usr/share/grub2/$(uname -m)-efi/grubbls.efi"
-	echo "$grub2"
+	grub2_bls="/usr/share/grub2/$(uname -m)-efi/grubbls.efi"
+	echo "$grub2_bls"
 }
 
 find_bootloader()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
 		find_sdboot "${1-$root_snapshot}"
-	elif is_grub2 "${1-$root_snapshot}"; then
-		find_grub2 "${1-$root_snapshot}"
+	elif is_grub2_bls "${1-$root_snapshot}"; then
+		find_grub2_bls "${1-$root_snapshot}"
 	else
 		err "Bootloader not detected"
 	fi
@@ -1716,7 +1717,7 @@ pcrlock_sdboot_cmdline_initrd()
 	rm "$tmpdir/cmdline.utf16"
 }
 
-pcrlock_grub2_kernel_initrd()
+pcrlock_grub2_bls_kernel_initrd()
 {
 	local linux="$1"
 	local initrd="$2"
@@ -1736,11 +1737,11 @@ pcrlock_grub2_kernel_initrd()
 	done
 	jq --slurp '{"records": [.[].records[0]]}' \
 	   "${locks[@]}" \
-	   > "/var/lib/pcrlock.d/710-grub2-kernel-initrd-entry.pcrlock.d/kernel-initrd-$suffix.pcrlock"
+	   > "/var/lib/pcrlock.d/710-grub2-bls-kernel-initrd-entry.pcrlock.d/kernel-initrd-$suffix.pcrlock"
 	rm "${locks[@]}"
 }
 
-pcrlock_grub2_cmdline()
+pcrlock_grub2_bls_cmdline()
 {
 	local linux="$1"
 	local cmdline="$2"
@@ -1763,11 +1764,11 @@ pcrlock_grub2_cmdline()
 	done
 	jq --slurp '{"records": [.[].records[0]]}' \
 	   "${locks[@]}" \
-	   > "/var/lib/pcrlock.d/650-grub2-entry-cmdline.pcrlock.d/cmdline-$suffix.pcrlock"
+	   > "/var/lib/pcrlock.d/650-grub2-bls-entry-cmdline.pcrlock.d/cmdline-$suffix.pcrlock"
 	rm "${locks[@]}"
 }
 
-pcrlock_grub2_entry_files()
+pcrlock_grub2_bls_entry_files()
 {
 	local entries="${1:-$entryfile}"
 	local suffix="${2:+-$2}"
@@ -1790,7 +1791,7 @@ pcrlock_grub2_entry_files()
 
 	jq --slurp '{"records": [.[].records[0]]}' \
 	   "${locks[@]}" \
-	   > "/var/lib/pcrlock.d/643-grub2-entry-files.pcrlock.d/generated$suffix.pcrlock"
+	   > "/var/lib/pcrlock.d/643-grub2-bls-entry-files.pcrlock.d/generated$suffix.pcrlock"
 	rm "${locks[@]}"
 }
 
@@ -1840,14 +1841,14 @@ pcrlock_sdboot()
 	fi
 }
 
-pcrlock_grub2()
+pcrlock_grub2_bls()
 {
-	# 643-grub2-entry-files.pcrlock is not part of the pcrlock
+	# 643-grub2-bls-entry-files.pcrlock is not part of the pcrlock
 	# standards
-	mkdir -p /var/lib/pcrlock.d/643-grub2-entry-files.pcrlock.d
-	pcrlock_grub2_entry_files
+	mkdir -p /var/lib/pcrlock.d/643-grub2-bls-entry-files.pcrlock.d
+	pcrlock_grub2_bls_entry_files
 	if [ "$SDB_ADD_INITIAL_COMPONENT" = "1" ]; then
-		pcrlock_grub2_entry_files "$initialentryfile" "0" "$tmpdir"
+		pcrlock_grub2_bls_entry_files "$initialentryfile" "0" "$tmpdir"
 	fi
 
 	blkpart="$(findmnt -nvo SOURCE "$boot_root")"
@@ -1855,21 +1856,21 @@ pcrlock_grub2()
 	# Once we are out of the BIOS / EFI, the numeration cannot be
 	# done without device.map.  It is safe to assume that the ESP
 	# is always the first disk (hd0)
-	grub_drive="(hd0,gpt$partno)"
+	grub2_bls_drive="(hd0,gpt$partno)"
 
 	# Join linux, initrd and cmdline in a single pcrlock file
-	mkdir -p /var/lib/pcrlock.d/650-grub2-entry-cmdline.pcrlock.d
+	mkdir -p /var/lib/pcrlock.d/650-grub2-bls-entry-cmdline.pcrlock.d
 	n=0
 	while read -r options; do
 		read -r kernel
 		read -r initrd
 		n=$((n+1))
-		pcrlock_grub2_cmdline "linux ${grub_drive}$kernel $options" \
-				      "${grub_drive}$kernel $options" \
-				      "initrd ${grub_drive}$initrd" "$n"
+		pcrlock_grub2_bls_cmdline "linux ${grub2_bls_drive}$kernel $options" \
+					  "${grub2_bls_drive}$kernel $options" \
+					  "initrd ${grub2_bls_drive}$initrd" "$n"
 	done < <(jq --raw-output '.[] | .options, .linux, .initrd[0]' "$entryfile")
 
-	# Generate variation for 650-grub2-entry-cmdline component
+	# Generate variation for 650-grub2-bls-entry-cmdline component
 	# that contains the current cmdline and the current initrd,
 	# even if this will never be used again.  This is required
 	# because disk-encryption-tool generates a new initrd during
@@ -1879,27 +1880,27 @@ pcrlock_grub2()
 		while read -r options; do
 			read -r kernel
 			read -r initrd
-			pcrlock_grub2_cmdline "linux ${grub_drive}$kernel $options" \
-					      "${grub_drive}$kernel $options" \
-					      "initrd ${grub_drive}$initrd" "0"
+			pcrlock_grub2_bls_cmdline "linux ${grub2_bls_drive}$kernel $options" \
+						  "${grub2_bls_drive}$kernel $options" \
+						  "initrd ${grub2_bls_drive}$initrd" "0"
 		done < <(jq --raw-output '.[] | .options, .linux, .initrd[0]' "$initialentryfile")
 	fi
 
 	# Join the kernel and the initrd in a single component
-	mkdir -p /var/lib/pcrlock.d/710-grub2-kernel-initrd-entry.pcrlock.d
+	mkdir -p /var/lib/pcrlock.d/710-grub2-bls-kernel-initrd-entry.pcrlock.d
 	n=0
 	while read -r kernel; do
 		read -r initrd
 		n=$((n+1))
-		pcrlock_grub2_kernel_initrd "$boot_root$kernel" "$boot_root$initrd" "$n"
+		pcrlock_grub2_bls_kernel_initrd "$boot_root$kernel" "$boot_root$initrd" "$n"
 	done < <(jq --raw-output '.[] | .linux, .initrd[0]' "$entryfile")
 
-	# Generate variation for 710-grub2-kernel-initrd-entry for the
+	# Generate variation for 710-grub2-bls-kernel-initrd-entry for the
 	# same reason than before.
 	if [ "$SDB_ADD_INITIAL_COMPONENT" = "1" ]; then
 		while read -r kernel; do
 			read -r initrd
-			pcrlock_grub2_kernel_initrd "$tmpdir$kernel" "$tmpdir$initrd" "0"
+			pcrlock_grub2_bls_kernel_initrd "$tmpdir$kernel" "$tmpdir$initrd" "0"
 		done < <(jq --raw-output '.[] | .linux, .initrd[0]' "$initialentryfile")
 	fi
 }
@@ -1952,7 +1953,7 @@ generate_tpm2_predictions_pcrlock()
 
 	# 640-boot-loader-efi-application is not part of the pcrlock
 	# standards
-	# This is measuing the systemd-boot EFI binary (named grub.efi)
+	# This is measuring the systemd-boot EFI binary (named grub.efi)
 	# TODO: move to systemd-boot-pcrlock.rpm
 	pcrlock \
 	    lock-pe \
@@ -1961,8 +1962,8 @@ generate_tpm2_predictions_pcrlock()
 
 	if is_sdboot; then
 		pcrlock_sdboot
-	elif is_grub2; then
-		pcrlock_grub2
+	elif is_grub2_bls; then
+		pcrlock_grub2_bls
 	fi
 
 	# If the prediction fails, the system will ask for a password,
@@ -2356,7 +2357,7 @@ enroll()
 		if [ -z "${FDE_SEAL_PCR_LIST}" ]; then
 			if is_sdboot; then
 				FDE_SEAL_PCR_LIST="0,2,4,7,9"
-			elif is_grub2; then
+			elif is_grub2_bls; then
 				FDE_SEAL_PCR_LIST="0,2,4,7,8,9"
 			else
 				err "Bootloader not detected"
@@ -2502,8 +2503,8 @@ bootloader_name()
 {
 	if is_sdboot "${1-$root_snapshot}"; then
 		echo "systemd-boot"
-	elif is_grub2 "${1-$root_snapshot}"; then
-		echo "grub2"
+	elif is_grub2_bls "${1-$root_snapshot}"; then
+		echo "grub2-bls"
 	else
 		err "Bootloader not detected"
 	fi
@@ -2621,7 +2622,7 @@ if [ -n "$arg_portable" ]; then
 	fi
 elif is_sdboot; then
 	boot_dst="/EFI/systemd"
-elif is_grub2; then
+elif is_grub2_bls; then
 	boot_dst="/EFI/opensuse"
 else
 	err "Bootloader not detected"

--- a/sdbootutil
+++ b/sdbootutil
@@ -219,8 +219,11 @@ warn()
 
 is_sdboot()
 {
-	# If systemd-boot and grub2-bls are co-installed, we favor
+	# LOADER_TYPE has preference, but is is not present and
+	# systemd-boot and grub2-bls are co-installed, we favor
 	# grub2-bls in the detection
+	[ -z "$LOADER_TYPE" ] || { [ "$LOADER_TYPE" = "systemd-boot" ]; return; }
+
 	local sdboot grub2_bls
 	sdboot="$(find_sdboot "${1-$root_snapshot}")"
 	grub2_bls="$(find_grub2_bls "${1-$root_snapshot}")"
@@ -229,8 +232,11 @@ is_sdboot()
 
 is_grub2_bls()
 {
-	# If systemd-boot and grub2-bls are co-installed, we favor
+	# LOADER_TYPE has preference, but is is not present and
+	# systemd-boot and grub2-bls are co-installed, we favor
 	# grub2-bls in the detection
+	[ -z "$LOADER_TYPE" ] || { [ "$LOADER_TYPE" = "grub2-bls" ]; return; }
+
 	local grub2_bls
 	grub2_bls="$(find_grub2_bls "${1-$root_snapshot}")"
 	[ -e "$grub2_bls" ]
@@ -2612,6 +2618,8 @@ case "$firmware_arch" in
 	aa64) image=Image ;;
 	*) err "Unsupported architecture $firmware_arch" ;;
 esac
+
+[ -e /etc/sysconfig/bootloader ] && . /etc/sysconfig/bootloader
 
 # XXX: Unify both in /EFI/opensuse?
 if [ -n "$arg_portable" ]; then


### PR DESCRIPTION
* Use /etc/sysconfig/bootloader to untie the bootloader detector
* `sdbootutil install` will change the boot order even if there is no new install