### PR TITLE
Bind mount snapshot dir onto itself before chroot.

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -620,6 +620,11 @@ mount_chroot()
 {
 	local snapshot_dir="$1"
 
+	#This is needed so that the rootfs appears in the mounts under
+	#the chroot, allowing dracut to properly detect the fs type
+	#and load the relevant module
+	mount --bind "$snapshot_dir $snapshot_dir"
+
 	mount -t tmpfs -o size=10m tmpfs "$snapshot_dir/run"
 	for i in proc dev sys var tmp; do
 		mount --bind "/$i" "$snapshot_dir/$i"
@@ -633,6 +638,8 @@ umount_chroot()
 	for i in proc dev sys var tmp run; do
 		umount "$snapshot_dir/$i"
 	done
+
+	umount "$snapshot_dir"
 }
 
 mount_etc()


### PR DESCRIPTION
This allows dracut running inside chroot to properly detect the root filesystem type and include the relevant dracut module.

When going inside chroot only the mounts under it are visible in /proc/mounts
the snashot directory in not a mountpoint itself, it's the upper level subvolume that's mounted. The bind mount to itself solves this issue, and makes it visible inside the chroot.

If there is an x-initrd.mount option in the fstab entry for the rootfs (seems to be the case for prebuilt images) this is not strictly needed, but there isn't one if using .iso and the installer.