### PR TITLE
rollback bootloader after setting default snapshot

### DIFF
--- a/10-sdbootutil.snapper
+++ b/10-sdbootutil.snapper
@@ -22,6 +22,7 @@ create_snapshot()
 	is_transactional && return 0
 
 	/usr/bin/sdbootutil add-all-kernels "$num" || :
+	/usr/bin/sdbootutil update --sync "$num" || :
 }
 
 delete_snapshot()
@@ -45,7 +46,6 @@ set_default_snapshot()
 
 	if is_transactional; then
 		/usr/bin/sdbootutil add-all-kernels "$num" || :
-		/usr/bin/sdbootutil update "$num" || :
 
 		if [ -e /usr/lib/module-init-tools/regenerate-initrd-posttrans ]; then
 			/usr/lib/module-init-tools/regenerate-initrd-posttrans
@@ -53,6 +53,7 @@ set_default_snapshot()
 	fi
 
 	/usr/bin/sdbootutil set-default-snapshot "$num" || :
+	/usr/bin/sdbootutil update --sync "$num" || :
 }
 
 h()

--- a/sdbootutil
+++ b/sdbootutil
@@ -20,6 +20,7 @@ arg_no_variables=
 arg_no_reuse_initrd=
 arg_no_random_seed=
 arg_portable=
+arg_sync=
 arg_only_default=
 arg_default_snapshot=
 arg_ask_pin_or_pw=
@@ -91,6 +92,7 @@ helpandquit()
 		  --entry-keys		Comma separated list of keys
 		  --no-variables	Do not update UEFI variables
 		  --no-reuse-initrd	Always regenerate initrd
+		  --sync		Synchronize (update, downgrade) the bootloader
 		  --portable		Handle bootloader on portable devices
 		  --only-default	Only list the default entry
 		  --default-snapshot	[SNAPSHOT] refers to the default snapshot
@@ -157,7 +159,8 @@ helpandquit()
 			   Check whether the bootloader in ESP needs updating
 
 		update
-			    Update the bootloader if it's old
+			    Update the bootloader if it's older than the deployed version.
+			    Use the --sync option to replace the deployed version also when it's newer
 
 		force-update
 			    Update the bootloader in any case
@@ -1471,10 +1474,18 @@ bootloader_needs_update()
 	nv="$(bootloader_version "$(find_bootloader "$snapshot")")"
 	[ -n "$v" ] || return 1
 	log_info "system version $nv"
-	systemd-analyze compare-versions "$v" lt "$nv" 2>/dev/null || return 1
+	systemd-analyze compare-versions "$v" "$nv" 2>/dev/null
+	local status="$?"
 	bldr_name=$(bootloader_name "$snapshot")
-	log_info "$bldr_name needs to be updated"
-	return 0
+	if [ "$status" = "11" ]; then
+		log_info "$bldr_name needs to be updated"
+		return 0
+	elif [ "$status" = "12" ]; then
+		log_info "$bldr_name is newer than system bootloader"
+		return 2
+	fi
+	log_info "$bldr_name is already up-to-date"
+	return 1
 }
 
 install_bootloader()
@@ -1554,6 +1565,17 @@ install_bootloader()
 
 	# This action will require to update the PCR predictions
 	update_predictions=1
+}
+
+bootloader_update()
+{
+	local status=0
+	bootloader_needs_update "${1:-$root_snapshot}" || status=$?
+	if [ $status -eq 0 ]; then
+		install_bootloader "${1:-$root_snapshot}"
+	elif [ -n "$arg_sync" ] && [ $status -eq 2 ]; then
+		install_bootloader "${1:-$root_snapshot}"
+	fi
 }
 
 hex_to_binary()
@@ -2707,7 +2729,7 @@ main_menu()
 
 ####### main #######
 
-getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy,generate-pin,unlock: -n "${0##*/}" -- "$@")
+getopttmp=$(getopt -o hc:v --long help,flicker,verbose,esp-path:,entry-token:,arch:,image:,entry-keys:,no-variables,no-reuse-initrd,no-random-seed,all,sync,portable,only-default,default-snapshot,ask-pin,ask-pw,method:,signed-policy,generate-pin,unlock: -n "${0##*/}" -- "$@")
 eval set -- "$getopttmp"
 
 while true ; do
@@ -2724,6 +2746,7 @@ while true ; do
 		--no-reuse-initrd) arg_no_reuse_initrd=1; shift ;;
 		--no-random-seed) arg_no_random_seed=1; shift ;;
 		--all) arg_all_entries=1; shift ;;
+		--sync) arg_sync=1; shift ;;
 		--portable) arg_portable=1; shift ;;
 		--only-default) arg_only_default=1; shift ;;
 		--default-snapshot) arg_default_snapshot=1; shift ;;
@@ -2824,7 +2847,7 @@ if [ "$1" = "install" ]; then
 elif [ "$1" = "needs-update" ]; then
 	bootloader_needs_update "${2:-$root_snapshot}"
 elif [ "$1" = "update" ]; then
-	if bootloader_needs_update "${2:-$root_snapshot}"; then install_bootloader "${2:-$root_snapshot}"; else :; fi
+	bootloader_update "${2:-$root_snapshot}"
 elif [ "$1" = "force-update" ]; then
 	if is_installed; then install_bootloader "${2:-$root_snapshot}"; else :; fi
 elif [ "$1" = "bootloader" ]; then


### PR DESCRIPTION
This makes sure that the bootloader version always matches the version found on the system