### PR TITLE
Show dracut output in verbose mode

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -815,11 +815,14 @@ install_kernel()
 	elif ! reuse_initrd "$snapshot" "$subvol" "$kernel_version"; then
 		local snapshot_dir="/.snapshots/$snapshot/snapshot"
 		local dracut_args=(
-			'--quiet'
 			'--reproducible'
 			'--force'
 			'--tmpdir' '/var/tmp'
 		)
+		if [ -z "$verbose" ]; then
+			dracut_args+=('--quiet')
+		fi
+		
 		log_info "generating new initrd"
 
 		[ "$subvol" != "$root_subvol" ] && [ -n "$have_snapshots" ] && mount_chroot "${snapshot_dir}"


### PR DESCRIPTION
When sdbootutil is called in non-verbose mode, the dracut output stays hidden

Otherwise, when a new initrd is generated, it is impossible to see what dracut does. The only way to check e.g. included modules is to either simulate running sdbootutil, but this is finnicky, or running dracut manually, which generates a useless initrd and then running sdbootutil again.