### PR TITLE
add info about how to ignore devices to --help

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -197,6 +197,11 @@ helpandquit()
 		PIN			Recovery PIN (re-enrollment; %u:sdbootutil)
 		PW			Password / Recovery Key (initial enrollment; %u:sdbootutil)
 					(%u:cryptenroll for changes via systemd-cryptenroll)
+
+		Misc:
+		Ignoring Devices	A LUKS2 device can be un-tracked (ignored) by sdbootutil if
+					is present in /etc/crypttab and has the "x-sdbootutil.ignore" option
+
 	EOF
 	exit 0
 }


### PR DESCRIPTION
Hello,

this is my first ever PR, please be kind :)

It simply adds information to the --help invocation about how to ignore LUKS2 devices you don't want to manage with sdbootutil.

It helped me when dealing with multiple encrypted OS installations on my machine and is a simple copy/paste from [a comment](https://github.com/openSUSE/sdbootutil/blob/f762ec762f805a93484211f228837d5c51f9747d/sdbootutil#L2107) inside the `detect_tracked_devices()` function.

Thanks!