### PR TITLE
Fix version compare and typo

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -164,14 +164,16 @@ helpandquit()
 		           is potentially bootable
 
 		install
-		           Install systemd-boot and shim into ESP
+		           Install the bootloader and shim into ESP
 
 		needs-update
 		           Check whether the bootloader in ESP needs updating
 
 		update
-		           Update the bootloader if it's older than the deployed
-		           version.  Use the --sync to allow downgrades
+		           Update the bootloader in the ESP if a newer version
+		           is available. Passing the --sync option will also
+		           allow downgrades, ensuring that the version in the ESP
+		           matches the one installed in the system.
 
 		force-update
 		           Update the bootloader in any case

--- a/sdbootutil
+++ b/sdbootutil
@@ -1274,7 +1274,7 @@ bootloader_needs_update()
 	[ -n "$v" ] || return 1
 	log_info "deployed version $v"
 	nv="$(bootloader_version "$(find_bootloader "$snapshot")")"
-	[ -n "$v" ] || return 1
+	[ -n "$nv" ] || return 1
 	log_info "system version $nv"
 	systemd-analyze compare-versions "$v" "$nv" 2>/dev/null
 	local status="$?"

--- a/sdbootutil
+++ b/sdbootutil
@@ -1278,11 +1278,11 @@ bootloader_needs_update()
 	local status="$?"
 	bldr_name=$(bootloader_name "$snapshot")
 	if [ "$status" = "11" ]; then
-		log_info "$bldr_name needs to be updated"
-		return 0
-	elif [ "$status" = "12" ]; then
 		log_info "$bldr_name is newer than system bootloader"
 		return 2
+	elif [ "$status" = "12" ]; then
+		log_info "$bldr_name needs to be updated"
+		return 0
 	fi
 	log_info "$bldr_name is already up-to-date"
 	return 1


### PR DESCRIPTION
This PR includes a fix from Michael to the version compare function between the bootloader installed in the ESP and the system one, which seems to be backwards. I also noticed a typo in a variable name and updated the help text.