### PR TITLE
Measure GPT of the disk with ESP, not the disk with root

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -2452,9 +2452,10 @@ generate_tpm2_predictions_pcrlock()
 	shift_component 620-secureboot-authority
 	pcrlock lock-secureboot-authority &> /dev/null || true
 
-	# Uses / by default
+	# Uses / by default, but firmware measures GPT of the disk a boot application
+	# was loaded from, which is effectively the disk where our ESP is located.
 	shift_component 600-gpt
-	pcrlock lock-gpt
+	pcrlock lock-gpt "$boot_root"
 
 	# 630-shim-efi-application is not part of the pcrlock standards
 	# TODO: move to shim-pcrlock.rpm


### PR DESCRIPTION
Firmware measures GPT of the disk where boot application was loaded from.
In practice it means ESP where we install our bootloader.

systemd-pcrlock defaults to the disk where root ("/") filesystem is
located. It can be anywhere and it can be on a virtual device, like
LUKS container or LVM, but it is not what firmware knows or measures.

Explicitly measure GPT with ESP to match the firmware behavior.

Fixes: #168
