### PR TITLE
Add local UKI support

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -1555,31 +1555,64 @@ list_entries()
 	done < <(jq '.[]|[.isDefault, if has("isReported") then .isReported else 0 end, if has("type") then .type else "unknown" end, .id, .root, .path, .showTitle]|join(" ")' -r < "$entryfile")
 }
 
-show_entry_fields()
-{
-	local snapshot="$1"
-	local kernel_version="$2"
-	[ -n "$kernel_version" ] || err "Missing kernel version"
-	settle_entry_token "${snapshot}"
-	local id
-	id="$(entry_conf_file "$kernel_version" "$snapshot")"
+show_entry_fields() {
+    local snapshot="$1"
+    local kernel_version="${2:?Missing kernel version}"
+    settle_entry_token "${snapshot}"
 
-	local conf
-	conf="$(find_conf_file "$kernel_version" "$snapshot")"
+    # --- Try classic type1 (BLS *.conf) first ---
+    local id conf
+    id="$(entry_conf_file "$kernel_version" "$snapshot")"
+    conf="$(find_conf_file "$kernel_version" "$snapshot" || true)"
+    if [ -n "$conf" ] && [ -f "$conf" ]; then
+        [ -z "$verbose" ] || echo -e "ID\t$id"
+        local k v
+        while read -r k v; do
+            case "$k" in title|version|sort-key|options|linux|initrd) ;; *) continue ;; esac
+            if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
+                echo -e "$k\t$v"
+            fi
+        done < "$conf"
+        return
+    fi
 
-	[ -z "$verbose" ] || echo -e "ID\t$id"
-	local k
-	local v
-	while read -r k v; do
-		case "$k" in
-			title|version|sort-key|options|linux|initrd) ;;
-			*) continue ;;
-		esac
+    # --- UKI (type2), only if it matches this snapshot ---
+    update_entries_for_snapshot "$snapshot"
 
-		if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
-			echo -e "$k\t$v"
-		fi
-	done < "$conf"
+    # Pull a single matching entry from entries.json:
+    #  - filename contains "-$kernel_version-<hash>.efi"
+    #  - options/cmdline contains rootflags for this snapshot
+    local entry_id title options linux_path
+    IFS=$'\t' read -r entry_id title options linux_path < <(
+        jq -r --arg kv "$kernel_version" --arg snap "$snapshot" '
+          .[] | select(type=="object")
+             | select(.linux? != null)
+             | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+             | select((.options? // .cmdline? // "")
+                      | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + ($snap|tostring) + "/snapshot( |$)"))
+             | [ .id, (.title // .showTitle // ""), (.options // .cmdline // ""), .linux ]
+             | @tsv
+        ' < "$entryfile" | head -n1
+    )
+
+    [ -n "$linux_path" ] || err "No UKI entry for kernel $kernel_version that matches snapshot $snapshot."
+    [ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
+
+    # Helper respecting --keys filtering
+    print_kv() {
+        local k="$1" v="$2"
+        if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
+            echo -e "$k\t$v"
+        fi
+    }
+
+    [ -z "$verbose" ] || echo -e "ID\t$entry_id"
+    print_kv title   "${title}"
+    # For type2 we don't get uname from the entry list; show the kernel version we were asked about.
+    print_kv version "${kernel_version}"
+    print_kv options "${options}"
+    print_kv linux   "${linux_path}"
+    print_kv initrd  "(embedded)"
 }
 
 update_entry_conf()

--- a/sdbootutil
+++ b/sdbootutil
@@ -3,7 +3,6 @@
 # SPDX-FileCopyrightText: Copyright 2023 SUSE LLC
 set -e
 shopt -s nullglob
-source "/etc/sdbootutil"
 
 DEBUG_LOG="/var/log/sdbootutil.log"
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -1556,63 +1556,144 @@ list_entries()
 }
 
 show_entry_fields() {
-    local snapshot="$1"
-    local kernel_version="${2:?Missing kernel version}"
-    settle_entry_token "${snapshot}"
+	local snapshot="$1"
+	local kernel_version="${2:?Missing kernel version}"
+	settle_entry_token "${snapshot}"
 
-    # --- Try classic type1 (BLS *.conf) first ---
-    local id conf
-    id="$(entry_conf_file "$kernel_version" "$snapshot")"
-    conf="$(find_conf_file "$kernel_version" "$snapshot" || true)"
-    if [ -n "$conf" ] && [ -f "$conf" ]; then
-        [ -z "$verbose" ] || echo -e "ID\t$id"
-        local k v
-        while read -r k v; do
-            case "$k" in title|version|sort-key|options|linux|initrd) ;; *) continue ;; esac
-            if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
-                echo -e "$k\t$v"
-            fi
-        done < "$conf"
-        return
-    fi
+	# --- Try classic type1 (BLS *.conf) first ---
+	local id conf
+	id="$(entry_conf_file "$kernel_version" "$snapshot")"
+	conf="$(find_conf_file "$kernel_version" "$snapshot" || true)"
+	if [ -n "$conf" ] && [ -f "$conf" ]; then
+		[ -z "$verbose" ] || echo -e "ID\t$id"
+		local k v
+		while read -r k v; do
+			case "$k" in title|version|sort-key|options|linux|initrd) ;; *) continue ;; esac
+			if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
+				echo -e "$k\t$v"
+			fi
+		done < "$conf"
+		return
+	fi
 
-    # --- UKI (type2), only if it matches this snapshot ---
-    update_entries_for_snapshot "$snapshot"
+	# --- UKI (type2), only if it matches this snapshot ---
+	update_entries_for_snapshot "$snapshot"
 
-    # Pull a single matching entry from entries.json:
-    #  - filename contains "-$kernel_version-<hash>.efi"
-    #  - options/cmdline contains rootflags for this snapshot
-    local entry_id title options linux_path
-    IFS=$'\t' read -r entry_id title options linux_path < <(
-        jq -r --arg kv "$kernel_version" --arg snap "$snapshot" '
-          .[] | select(type=="object")
-             | select(.linux? != null)
-             | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
-             | select((.options? // .cmdline? // "")
-                      | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + ($snap|tostring) + "/snapshot( |$)"))
-             | [ .id, (.title // .showTitle // ""), (.options // .cmdline // ""), .linux ]
-             | @tsv
-        ' < "$entryfile" | head -n1
-    )
+	# Pull a single matching entry from entries.json:
+	#  - filename contains "-$kernel_version-<hash>.efi"
+	#  - options/cmdline contains rootflags for this snapshot
+	local entry_id title options linux_path
+	IFS=$'\t' read -r entry_id title options linux_path < <(
+		jq -r --arg kv "$kernel_version" --arg snap "$snapshot" '
+		  .[] | select(type=="object")
+			 | select(.linux? != null)
+			 | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+			 | select((.options? // .cmdline? // "")
+					  | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + ($snap|tostring) + "/snapshot( |$)"))
+			 | [ .id, (.title // .showTitle // ""), (.options // .cmdline // ""), .linux ]
+			 | @tsv
+		' < "$entryfile" | head -n1
+	)
 
-    [ -n "$linux_path" ] || err "No UKI entry for kernel $kernel_version that matches snapshot $snapshot."
-    [ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
+	[ -n "$linux_path" ] || err "No UKI entry for kernel $kernel_version that matches snapshot $snapshot."
+	[ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
 
-    # Helper respecting --keys filtering
-    print_kv() {
-        local k="$1" v="$2"
-        if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
-            echo -e "$k\t$v"
-        fi
-    }
+	# Helper respecting --keys filtering
+	print_kv() {
+		local k="$1" v="$2"
+		if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
+			echo -e "$k\t$v"
+		fi
+	}
 
-    [ -z "$verbose" ] || echo -e "ID\t$entry_id"
-    print_kv title   "${title}"
-    # For type2 we don't get uname from the entry list; show the kernel version we were asked about.
-    print_kv version "${kernel_version}"
-    print_kv options "${options}"
-    print_kv linux   "${linux_path}"
-    print_kv initrd  "(embedded)"
+	[ -z "$verbose" ] || echo -e "ID\t$entry_id"
+	print_kv title   "${title}"
+	# For type2 we don't get uname from the entry list; show the kernel version we were asked about.
+	print_kv version "${kernel_version}"
+	print_kv options "${options}"
+	print_kv linux   "${linux_path}"
+	print_kv initrd  "(embedded)"
+}
+
+find_uki_for_snapshot() {
+	local snapshot="$1"
+	local kernel_version="$2"
+
+	update_entries_for_snapshot "$snapshot"
+
+	jq -r --arg kv "$kernel_version" --arg snap "$snapshot" '
+	  .[] | select(type=="object")
+		 | select(.linux? != null)
+		 | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+		 | select(
+			 (.options? // .cmdline? // "")
+			 | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + ($snap|tostring) + "/snapshot( |$)")
+		   )
+		 | [ .id, .linux, (.options // .cmdline // ""), (.title // .showTitle // "") ]
+		 | @tsv
+	' < "$entryfile" | head -n1
+}
+
+update_uki_entry_conf() {
+	local snapshot="$1"
+	local kernel_version="$2"
+
+	# Locate matching UKI in entries.json
+	local entry_id linux_path old_opts title
+	IFS=$'\t' read -r entry_id linux_path old_opts title < <(find_uki_for_snapshot "$snapshot" "$kernel_version")
+	[ -n "$linux_path" ] || err "No UKI entry for kernel $kernel_version that matches snapshot $snapshot."
+	[ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
+
+	# Compute subvol & new cmdline
+	local subvol=""
+	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	local boot_options
+	boot_options="$(create_boot_options "$subvol")"
+
+	# Title: prefer the one from entries.json, else fall back
+	local effective_title="${title:-${os_release_PRETTY_NAME:-Linux $kernel_version}}"
+
+	# Derive checksum from filename (…/openSUSE-<kv>-<sum>.efi)
+	local fname sum kvdir ukidir_kv linuxdir
+	fname="${linux_path##*/}"
+	sum="${fname%.efi}"
+	sum="${sum#openSUSE-$kernel_version-}"
+	linuxdir="$boot_root/EFI/Linux"
+	ukidir_kv="${ukidir}/${kernel_version}-${sum}"
+
+	[ -d "$ukidir_kv" ] || err "UKI working dir not found: $ukidir_kv (kernel $kernel_version, sum $sum)."
+
+	# (Re)build this snapshot's profile
+	info "Updating UKI profile for snapshot $snapshot (kernel $kernel_version)"
+	ukify build \
+		--profile="TITLE=${effective_title}${nl}ID=${snapshot}" \
+		--cmdline="$boot_options" \
+		--output="${ukidir_kv}/profile-${snapshot}.efi"
+
+	# Rebuild the UKI joining ALL initrds and ALL profile-*.efi that still exist
+	local tmp_uki="$tmpdir/uki-${kernel_version}.efi"
+	local ukify_args=( --linux="${ukidir_kv}/${image}" --output="$tmp_uki" )
+
+	shopt -s nullglob
+	local f
+	for f in "${ukidir_kv}"/initrd-*; do
+		[ -f "$f" ] && ukify_args+=( --initrd="$f" )
+	done
+	for f in "${ukidir_kv}"/profile-*.efi; do
+		[ -f "$f" ] && ukify_args+=( --join-profile="$f" )
+	done
+	shopt -u nullglob
+
+	info "Rebuilding UKI image for kernel $kernel_version"
+	ukify build "${ukify_args[@]}"
+
+	make_free_space_for_uki "$snapshot" "$tmp_uki" || err "No free space in $boot_root for rebuilt UKI"
+	install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-${kernel_version}-${sum}.efi" || err "Failed to install rebuilt UKI"
+	rm -f "$tmp_uki"
+	reset_rollback
+
+	# Predictors need refresh
+	update_predictions=1
 }
 
 update_entry_conf()
@@ -1631,38 +1712,61 @@ update_entry_conf()
 	cp "$tmpdir/entry.conf" "$conf"
 }
 
-update_entry()
-{
+update_entry() {
 	local snapshot="$1"
 	local kernel_version="$2"
 
 	settle_entry_token "${snapshot}"
-	local id
-	id="$(entry_conf_file "$kernel_version" "$snapshot")"
 
+	# Type1 first
 	local conf
-	conf="$(find_conf_file "$kernel_version" "$snapshot")"
-	[ -f "$conf" ] || return 0
+	conf="$(find_conf_file "$kernel_version" "$snapshot" || true)"
+	if [ -n "$conf" ] && [ -f "$conf" ]; then
+		local id
+		id="$(entry_conf_file "$kernel_version" "$snapshot")"
+		info "Updating boot entry $id"
+		update_entry_conf "$conf" "$snapshot"
+		update_predictions=1
+		return
+	fi
 
-	info "Updating boot entry $id"
-	update_entry_conf "$conf" "$snapshot"
+	# UKI path
+	if [ -n "${use_uki:-1}" ]; then
+		info "Updating UKI entry for kernel $kernel_version (snapshot $snapshot)"
+		update_uki_entry_conf "$snapshot" "$kernel_version"
+		return
+	fi
 
-	# This action will require to update the PCR predictions
-	update_predictions=1
+	warn "No entry found to update for kernel $kernel_version (snapshot $snapshot)"
 }
 
-update_all_entries()
-{
+update_all_entries() {
 	local snapshot="$1"
-
 	make_free_space "$snapshot" 1024
 
-	update_entries_for_snapshot "$1"
-	while read -r conf; do
-		update_entry_conf "$conf" "$snapshot"
-	done < <(jq -r '.[]|.path' < "$entryfile")
+	update_entries_for_snapshot "$snapshot"
 
-	# This action will require to update the PCR predictions
+	# Update classic BLS entries (have .path that is a *.conf on disk)
+	while read -r conf; do
+		[ -f "$conf" ] || continue
+		update_entry_conf "$conf" "$snapshot"
+	done < <(jq -r '.[] | select(.path? != null) | .path' < "$entryfile")
+
+	# Update UKI entries (have .linux pointing to /EFI/Linux/openSUSE-<kv>-<sum>.efi)
+	# Extract kernel version from the filename and rebuild each once.
+	local kvs_seen=()
+	while read -r linux_path; do
+		[ -n "$linux_path" ] || continue
+		local base kv
+		base="${linux_path##*/}"                 # openSUSE-<kv>-<sum>.efi
+		kv="${base#openSUSE-}"; kv="${kv%-*}"    # strip prefix and trailing -<sum>.efi
+		# de-duplicate kernel versions in case multiple entries point to the same UKI
+		if [[ " ${kvs_seen[*]} " != *" $kv "* ]]; then
+			kvs_seen+=("$kv")
+			update_uki_entry_conf "$snapshot" "$kv"
+		fi
+	done < <(jq -r '.[] | .linux? // empty' < "$entryfile")
+
 	update_predictions=1
 }
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -642,40 +642,31 @@ remove_uki()
 	local snapshot="${1:?}"
 	local kernel_version="${2:?}"
 	local ker_chksum="${3:-}"
-
-	# Compute sum if not provided
-	if [ -z "$ker_chksum" ]; then
-		ker_chksum="$(kernel_sum_for_snapshot "$snapshot" "$kernel_version")"
-	fi
-
-	local work; work="$(build_uki_workdir "$kernel_version" "$ker_chksum")"
-	local prof="$work/profile-${snapshot}.efi"
 	local linuxdir="$boot_root/EFI/Linux"
 
-	if [ -f "$prof" ]; then
-		info "Deleting profile for snapshot $snapshot"
-		rm -f "$prof"
-	else
-		warn "Profile for snapshot $snapshot not found; skipping delete"
-	fi
+	# If checksum was not provided, discover all UKIs for this kernel on the ESP
+	if [ -z "$ker_chksum" ]; then
+		local f basename ksum found=0
 
-	shopt -s nullglob
-	local remaining_profiles=( "$work"/profile-*.efi )
-	shopt -u nullglob
+		shopt -s nullglob
+		for f in "$linuxdir"/openSUSE-"$kernel_version"-[0-9a-f][0-9a-f][0-9a-f]*.efi; do
+			basename="${f##*/}"
+			if [[ "$basename" =~ ^openSUSE-.+-([0-9a-f]{40})-[0-9a-f]{40}\.efi$ ]]; then
+				ksum="${BASH_REMATCH[1]}"
+			else
+				continue
+			fi
 
-	if [ "${#remaining_profiles[@]}" -gt 0 ]; then
-		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
-		local out="$tmpdir/uki-${kernel_version}.efi"
-		build_uki_image "$kernel_version" "$ker_chksum" "$out" "$snapshot"
-		make_free_space_for_uki "$snapshot" "$out" || err "No free space for rebuilt UKI"
-		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
-		rm -f "$out"
-		[ -z "$failed" ] || err "Failed to install $failed"
-		reset_rollback
+			regenerate_uki "$kernel_version" "$ksum" "$snapshot"
+			found=1
+		done
+		shopt -u nullglob
+
+		if [ "$found" -eq 0 ]; then
+			warn "No UKIs for kernel $kernel_version found on ESP; nothing to remove"
+		fi
 	else
-		info "No snapshots left for $kernel_version; removing all artifacts"
-		rm -rf "$work"
-		rm -f "$linuxdir/openSUSE-${kernel_version}-"*.efi
+		regenerate_uki "$kernel_version" "$ker_chksum" "$snapshot"
 	fi
 
 	update_predictions=1
@@ -807,10 +798,38 @@ reuse_initrd()
 	[ -z "$arg_no_reuse_initrd" ] || return 1
 	settle_entry_token "${snapshot}"
 
-	# Check if in our UKI build dir is our initrd
 	if use_uki; then
-		[ -f "${ukidir}/${kernel_version}-${ker_chksum}/initrd-0" ]
-		return $?
+		# Try current snapshot's UKI for this kernel version
+		local tsv linux_path kv ksum isum work
+		tsv="$(find_uki_entry "$snapshot" "$kernel_version" || true)"
+		if [ -n "$tsv" ]; then
+			linux_path="$(printf '%s' "$tsv" | awk -F'\t' '{print $2}')"
+			read -r kv ksum isum < <(uki_sum_from_path "$linux_path") || true
+			[ -n "$isum" ] || return 1
+			work="$(build_uki_workdir "$kernel_version" "$ker_chksum" "$isum")"
+			if [ -f "${work}/initrd-0" ]; then
+				dstinitrd=( "${work}/initrd-0" )
+				info "Reusing current snapshot UKI initrd at ${dstinitrd[0]}"
+				return 0
+			fi
+		fi
+
+		# Try parent snapshot's UKI
+		detect_parent "$subvol"
+		[ -n "$parent_subvol" ] || return 1
+		tsv="$(find_uki_entry "$parent_snapshot" "$kernel_version" || true)"
+		[ -n "$tsv" ] || return 1
+		linux_path="$(printf '%s' "$tsv" | awk -F'\t' '{print $2}')"
+		read -r kv ksum isum < <(uki_sum_from_path "$linux_path") || true
+		[ -n "$isum" ] || return 1
+		work="$(build_uki_workdir "$kernel_version" "$ker_chksum" "$isum")"
+		if [ -f "${work}/initrd-0" ]; then
+			dstinitrd=( "${work}/initrd-0" )
+			info "Reusing parent snapshot UKI initrd at ${dstinitrd[0]}"
+			return 0
+		fi
+
+		return 1
 	fi
 
 	conf="$(find_conf_file "$kernel_version" "${snapshot}")"
@@ -843,11 +862,11 @@ reuse_initrd()
 
 reuse_profile()
 {
-	local snapshot="${1:?}" kernel_version="${2:?}"
+	local snapshot="${1:?}" kernel_version="${2:?}" isum="${3:?}"
 
 	[ -z "$arg_no_reuse_profile" ] || return 1
 	local sum; sum="$(kernel_sum_for_snapshot "$snapshot" "$kernel_version")"
-	[ -f "$(build_uki_workdir "$kernel_version" "$sum")/profile-${snapshot}.efi" ]
+	[ -f "$(build_uki_workdir "$kernel_version" "$sum" "$isum")/profile-${snapshot}.efi" ]
 }
 
 mount_chroot()
@@ -1151,13 +1170,26 @@ make_free_space_for_uki()
 	select_uki_entries_for_free_space "$snapshot"
 
 	# Remove low-priority UKIs until we have enough space
-	local id
+	local id linux_path kv ksum isum workdir
 	while read -r id; do
 		free_space="$(boot_free_space)"
 		dbg "Free space in the ESP: $free_space KB"
 		if [ "$total_size" -gt "$free_space" ]; then
-			info "Removing UKI via boot entry $id"
+			# Look up the Linux path for this entry
+			linux_path="$(jq -r --arg id "$id" '.[] | select(.id == $id) | .linux' < "$entryfile")"
+			info "Removing UKI via boot entry $id ($linux_path)"
 			bootctl unlink "$id"
+
+			# Clean up corresponding workdir in $ukidir
+			if [ -n "$linux_path" ]; then
+				if read -r kv ksum isum < <(uki_sum_from_path "$linux_path"); then
+					workdir="$(build_uki_workdir "$kv" "$ksum" "$isum")"
+					if [ -d "$workdir" ]; then
+						info "Removing UKI workdir $workdir"
+						rm -rf -- "$workdir"
+					fi
+				fi
+			fi
 		else
 			return 0
 		fi
@@ -1259,29 +1291,43 @@ install_kernel()
 	fi
 
 	if use_uki; then
-		# Copy initrds into workdir
-		local i=0 work; work="$(build_uki_workdir "$kernel_version" "$ker_chksum")"
-		while [ -e "$tmpdir/initrd-$i" ]; do
-			install_with_rollback "$tmpdir/initrd-$i" "$work/initrd-$i" || { failed=initrd; break; }
-			rm -f "$tmpdir/initrd-$i"
-			((++i))
-		done
-		ensure_image_in_workdir "$snapshot" "$kernel_version" "$ker_chksum"
+		local isum workdir
 
-		# Create/refresh this snapshot's profile if missing or --no-reuse-profile
-		if ! reuse_profile "$snapshot" "$kernel_version"; then
-			build_uki_profile "$snapshot" "$kernel_version" "$ker_chksum" "$boot_options"
+		if [ -n "${dstinitrd[0]:-}" ] && [ -f "${dstinitrd[0]}" ]; then
+			calc_chksum "${dstinitrd[0]}"
+			isum="$chksum"
+			workdir="$(build_uki_workdir "$kernel_version" "$ker_chksum" "$isum")"
+			[ -f "${workdir}/initrd-0" ] || install_with_rollback "${dstinitrd[0]}" "${workdir}/initrd-0"
+		else
+			[ -e "$tmpdir/initrd-0" ] || err "Missing temporary initrd-0; cannot compute checksum"
+			calc_chksum "$tmpdir/initrd-0"
+			isum="$chksum"
+			workdir="$(build_uki_workdir "$kernel_version" "$ker_chksum" "$isum")"
+			install_with_rollback "$tmpdir/initrd-0" "${workdir}/initrd-0"
+			rm -f "$tmpdir/initrd-0"
+			dstinitrd=( "${workdir}/initrd-0" )
+		fi
+
+		[ -n "$isum" ] || err "Unable to determine initrd checksum for UKI"
+
+		ensure_image_in_workdir "$snapshot" "$kernel_version" "$ker_chksum" "$isum"
+
+		if ! reuse_profile "$snapshot" "$kernel_version" "$isum"; then
+			build_uki_profile "$snapshot" "$kernel_version" "$ker_chksum" "$isum" "$boot_options"
 		else
 			info "Found existing UKI profile for snapshot $snapshot"
 		fi
 
-		# Build the combined UKI
-		local out="$tmpdir/uki-${kernel_version}.efi"
-		build_uki_image "$kernel_version" "$ker_chksum" "$out" "$snapshot"
+		local out="$tmpdir/uki-${kernel_version}-${isum}.efi"
+		build_uki_image "$kernel_version" "$ker_chksum" "$out" "$snapshot" "$isum"
 		make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for new UKI"
-		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
+
+		local target="${linuxdir}/openSUSE-${kernel_version}-${ker_chksum}-${isum}.efi"
+		install_with_rollback "$out" "$target" || failed="UKI"
 		rm -f "$out"
 		[ -z "$failed" ] || err "Failed to install $failed"
+
+		clean_profile_from_other_ukis "$kernel_version" "$ker_chksum" "$snapshot" "$isum"
 		reset_rollback
 		update_predictions=1
 		return
@@ -1546,7 +1592,7 @@ show_entry_fields()
 		jq -r --arg kv "$kernel_version" --arg snap "$snapshot" '
 		  .[] | select(type=="object")
 			 | select(.linux? != null)
-			 | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+			 | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}-[0-9a-f]{40}\\.efi$"))
 			 | select((.options? // .cmdline? // "")
 					  | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + ($snap|tostring) + "/snapshot( |$)"))
 			 | [ .id, (.title // .showTitle // ""), (.options // .cmdline // ""), .linux ]
@@ -1605,7 +1651,8 @@ update_uki_profile()
 	[ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
 
 	# Derive kv/sum & ensure linux staged in workdir
-	local _kv sum; read -r _kv sum < <(uki_sum_from_path "$linux_path")
+	local _kv sum isum
+	read -r _kv sum isum < <(uki_sum_from_path "$linux_path")
 	local work; work="$(build_uki_workdir "$kv" "$sum")"
 	[ -d "$work" ] || err "UKI working dir not found: $work"
 
@@ -1613,11 +1660,11 @@ update_uki_profile()
 	local boot_options; boot_options="$(create_boot_options "$subvol")"
 
 	info "Updating UKI profile for snapshot $snapshot (kernel $kv)"
-	build_uki_profile "$snapshot" "$kv" "$sum" "$boot_options"
+	build_uki_profile "$snapshot" "$kv" "$sum" "$isum" "$boot_options"
 
 	local out="$tmpdir/uki-${kv}.efi"
 	info "Rebuilding UKI image for kernel $kv"
-	build_uki_image "$kv" "$sum" "$out" "$snapshot"
+	build_uki_image "$kv" "$sum" "$out" "$snapshot" "$isum"
 	make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for rebuilt UKI"
 	install_with_rollback "$out" "$boot_root/EFI/Linux/openSUSE-${kv}-${sum}.efi" || err "Failed to install rebuilt UKI"
 	rm -f "$out"
@@ -1745,44 +1792,44 @@ find_kernels()
 	done
 }
 
-# Map that uses expected path on the ESP for each installed kernel as
-# key.  The value is the entry id if an entry exists.
-declare -A installed_kernels
-# Map of ESP path to id of kernels that are not in the subvol
+declare -A kv_expected kv_matched kv_example_path kv_example_id
 declare -A stale_kernels
 is_bootable=
-update_kernels()
-{
+
+update_kernels() {
 	local snapshot="$1"
-	local path id sum
-	installed_kernels=()
+	local path id kv
+	kv_expected=()
+	kv_matched=()
+	kv_example_path=()
+	kv_example_id=()
 	stale_kernels=()
 	is_bootable=
+
 	find_kernels "$snapshot"
-	settle_entry_token "${snapshot}"	
-	# Seed expected ESP paths for each found kernel version
+	settle_entry_token "${snapshot}"
+
+	# seed expected KVs from what we found in /usr/lib/modules
 	for kv in "${!found_kernels[@]}"; do
-		sum="${found_kernels[$kv]}"
-		# classic BLS kernel image path
-		installed_kernels["/$entry_token/$kv/linux-$sum"]=''
-		# UKI path used by sdbootutil (and bootctl type2)
-		installed_kernels["/EFI/Linux/openSUSE-$kv-$sum.efi"]=''
-	done	
-	update_entries_for_snapshot "$snapshot"	
-	# Fill matches from bootctl JSON and mark truly stale ones
+		kv_expected["$kv"]=1
+	done
+
+	update_entries_for_snapshot "$snapshot"
+
 	while read -r path id; do
-		if [[ -v 'installed_kernels[$path]' ]]; then
-			installed_kernels["$path"]="$id"
+		kv="$(kv_from_any "$path" "$snapshot")"
+		if [ -n "$kv" ] && [[ -v 'kv_expected[$kv]' ]]; then
+			kv_matched["$kv"]=1
+			kv_example_path["$kv"]="$path"
+			kv_example_id["$kv"]="$id"
 			is_bootable=1
-		# mark "stale" only if it looks like one of our kernel layouts
 		elif [[ "$path" == /$entry_token/*/linux-* || "$path" == /EFI/Linux/openSUSE-*.efi ]]; then
 			stale_kernels["$path"]="$id"
 		fi
 	done < <(jq -r '.[]|select(has("linux"))|[.linux,.id]|join(" ")' < "$entryfile")
 }
 
-list_kernels()
-{
+list_kernels() {
 	local snapshot=""
 	[ -z "$have_snapshots" ] || snapshot="${1:?}"
 
@@ -1790,33 +1837,16 @@ list_kernels()
 
 	update_kernels "$snapshot"
 
-	# Aggregate by kv: ok if any layout matched
-	declare -A kv_any_matched kv_any_expected kv_example_path kv_example_id
-	local k id kv
-
-	for k in "${!installed_kernels[@]}"; do
-		kv="$(kv_from_any "$k" "$snapshot")"
-		[ -n "$kv" ] || continue
-		kv_any_expected["$kv"]=1
-		id="${installed_kernels[$k]}"
-		if [ -n "$id" ]; then
-			kv_any_matched["$kv"]=1
-			kv_example_path["$kv"]="$k"
-			kv_example_id["$kv"]="$id"
-		fi
-	done
-
-	# Print once per kernel version
-	for kv in "${!kv_any_expected[@]}"; do
-		if [ -n "${kv_any_matched[$kv]+x}" ]; then
-			# show a representative mapping
+	local kv
+	for kv in "${!kv_expected[@]}"; do
+		if [ -n "${kv_matched[$kv]+x}" ]; then
 			echo -e "${color_green}ok /lib/modules/$kv/$image -> ${kv_example_id[$kv]}${color_end}"
 		else
 			echo -e "${color_yellow}missing /lib/modules/$kv/$image${color_end}"
 		fi
 	done
 
-	# Stale: entries that look like our kernel layouts but don’t belong to this snapshot
+	local k
 	for k in "${!stale_kernels[@]}"; do
 		printf "${color_red}stale %s${color_end}\n" "${stale_kernels[$k]}"
 	done
@@ -2130,13 +2160,6 @@ loader_conf_get()
 	fi
 }
 
-# Try to extract <KV> from *any* token:
-#   - BLS path:   /<entry_token>/<KV>/linux-<sha>
-#   - UKI path:   /EFI/Linux/openSUSE-<KV>-<sha>.efi
-#   - UKI id:     openSUSE-<KV>-<sha>.efi[@<snap>]
-#   - BLS id:     *-<KV>-<snap>[+tries].conf
-#   - UKI/BLS basenames work too (see above)
-# Returns KV to stdout; empty string if unknown.
 kv_from_any() {
 	local t="${1:?}"
 	t="${t#/boot/efi}"
@@ -2148,7 +2171,7 @@ kv_from_any() {
 	fi
 
 	# Type2 path: /EFI/Linux/openSUSE-<KV>-<sha>.efi
-	if [[ "$t" =~ ^/EFI/Linux/openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi$ ]]; then
+	if [[ "$t" =~ ^/EFI/Linux/openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}-[0-9a-f]{40}\.efi$ ]]; then
 		printf '%s\n' "${BASH_REMATCH[1]}"; return 0
 	fi
 
@@ -2156,7 +2179,7 @@ kv_from_any() {
 	local base="${t##*/}"
 
 	# UKI id/basename: openSUSE-<KV>-<sha>.efi[@<snap>]
-	if [[ "$base" =~ ^openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi(@[0-9]+)?$ ]]; then
+	if [[ "$base" =~ ^openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}-[0-9a-f]{40}\.efi(@[0-9]+)?$ ]]; then
 		printf '%s\n' "${BASH_REMATCH[1]}"; return 0
 	fi
 
@@ -2364,8 +2387,12 @@ build_uki_workdir()
 {
 	local kv="${1:?}"
 	local sum="${2:?}"
+	local isum="${3:-}"
 	local linuxdir="$boot_root/EFI/Linux"
-	local dir="${ukidir}/${kv}-${sum}"
+	local dir
+
+	dir="${ukidir}/${kv}-${sum}-${isum}"
+
 	mkdir -p "$linuxdir"
 	mkdir -p "$dir"
 
@@ -2377,13 +2404,82 @@ build_uki_workdir()
 	echo "$dir"
 }
 
+regenerate_uki()
+{
+	local kv="${1:?}" ksum="${2:?}" snap="${3:?}" skip_isum="${4:-}"
+	local linuxdir="$boot_root/EFI/Linux"
+
+	shopt -s nullglob
+	local f basename isum dir out removed
+	for f in "$linuxdir"/openSUSE-"$kv"-"$ksum"-[0-9a-f][0-9a-f][0-9a-f]*.efi; do
+		basename="${f##*/}"
+		if [[ "$basename" =~ ^openSUSE-.+-[0-9a-f]{40}-([0-9a-f]{40})\.efi$ ]]; then
+			isum="${BASH_REMATCH[1]}"
+		else
+			continue
+		fi
+
+		# skip current UKI if requested
+		[ -n "$skip_isum" ] && [ "$isum" = "$skip_isum" ] && continue
+
+		dir="$(build_uki_workdir "$kv" "$ksum" "$isum")"
+
+		removed=0
+		if [ -f "${dir}/profile-${snap}.efi" ]; then
+			rm -f -- "${dir}/profile-${snap}.efi"
+			info "Removed profile ${snap} from UKI (kv=${kv} ksum=${ksum} isum=${isum})"
+			removed=1
+		fi
+
+		# If nothing was removed here, do nothing for this UKI.
+		[ "$removed" -eq 1 ] || continue
+
+		# Any profiles left in this workdir?
+		shopt -s nullglob
+		set -- "${dir}"/profile-*.efi
+		shopt -u nullglob
+		if [ $# -eq 0 ]; then
+			# No profiles left: delete EFI file and workdir
+			info "No profiles left for UKI (kv=${kv} ksum=${ksum} isum=${isum}); removing it"
+			rm -f -- "$f"
+			rm -rf -- "$dir"
+			continue
+		fi
+
+		# Profiles remain: rebuild that specific UKI
+		out="$tmpdir/uki-${kv}-${isum}.efi"
+		build_uki_image "$kv" "$ksum" "$out" "$snap" "$isum"
+		make_free_space_for_uki "$snap" "$out" || err "No free space in $boot_root for rebuilt UKI"
+		install_with_rollback "$out" "$f" || failed="UKI"
+		rm -f "$out"
+		[ -z "${failed:-}" ] || err "Failed to install rebuilt UKI"
+		reset_rollback
+	done
+	shopt -u nullglob
+}
+
+# Replace previous clean_profile_from_other_ukis with this thin wrapper.
+# Removes the snapshot's profile from *other* UKIs (same kv/ksum, different initrd),
+# and for each such UKI either rebuilds it, or deletes it entirely when empty.
+# Usage: clean_profile_from_other_ukis "<kv>" "<ksum>" "<snapshot>" "<current_isum>"
+clean_profile_from_other_ukis()
+{
+	local kv="${1:?}" ksum="${2:?}" snap="${3:?}" curr_isum="${4:?}"
+	regenerate_uki "$kv" "$ksum" "$snap" "$curr_isum"
+}
+
 uki_sum_from_path()
 {
-	local p="${1:?}"; local base kv sum
-	base="${p##*/openSUSE-}"             # <kv>-<sum>.efi
-	[[ "$base" =~ ^(.+)-([0-9a-f]{40})\.efi$ ]] || return 1
-	kv="${BASH_REMATCH[1]}"; sum="${BASH_REMATCH[2]}"
-	echo "$kv $sum"
+	local p="${1:?}"; local base kv ksum isum
+	base="${p##*/openSUSE-}"
+
+	if [[ "$base" =~ ^(.+)-([0-9a-f]{40})-([0-9a-f]{40})\.efi$ ]]; then
+		kv="${BASH_REMATCH[1]}"; ksum="${BASH_REMATCH[2]}"; isum="${BASH_REMATCH[3]}"
+		echo "$kv $ksum $isum"
+		return 0
+	fi
+
+	return 1
 }
 
 kernel_sum_for_snapshot()
@@ -2514,14 +2610,14 @@ ukify_collect_args()
 
 build_uki_profile()
 {
-	local snap="${1:?}" kv="${2:?}" sum="${3:?}" cmd="${4:?}"
+	local snap="${1:?}" kv="${2:?}" sum="${3:?}" isum="${4:?}" cmd="${5:?}"
 	local title="${snapshot}@${kv}"
 	local subvol=""
 	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
 	if subvol_is_ro "$subvol" && ! is_transactional; then
 		title="Snapper: $title"
 	fi
-	local dir; dir="$(build_uki_workdir "$kv" "$sum")"
+	local dir; dir="$(build_uki_workdir "$kv" "$sum" "$isum")"
 	mkdir -p "$dir"
 	ukify build \
 		--profile="TITLE=${title}${nl}ID=${snap}" \
@@ -2531,8 +2627,10 @@ build_uki_profile()
 
 build_uki_image()
 {
-	local kv="${1:?}" sum="${2:?}" out="${3:?}" snapshot="${4:?}"
-	local dir; dir="$(build_uki_workdir "$kv" "$sum")"
+	local kv="${1:?}" ksum="${2:?}" out="${3:?}" snapshot="${4:?}"
+	local isum="${5:?}"
+
+	local dir; dir="$(build_uki_workdir "$kv" "$ksum" "$isum")"
 	local linux_src="${dir}/${image}"
 	[ -f "$linux_src" ] || err "Missing ${linux_src} (kernel copy not staged)."
 
@@ -2542,8 +2640,8 @@ build_uki_image()
 
 ensure_image_in_workdir()
 {
-	local snap="${1:?}" kv="${2:?}" sum="${3:?}"
-	local work; work="$(build_uki_workdir "$kv" "$sum")"; mkdir -p "$work"
+	local snap="${1:?}" kv="${2:?}" sum="${3:?}" isum="${4:?}"
+	local work; work="$(build_uki_workdir "$kv" "$sum" "$isum")"; mkdir -p "$work"
 	local src="${subvol_prefix}/.snapshots/${snap}/snapshot"
 	src="${src#"${subvol_prefix}"}/lib/modules/${kv}/${image}"
 	[ -f "${work}/${image}" ] || cp "$src" "${work}/${image}"
@@ -2557,7 +2655,8 @@ find_uki_entry()
 	update_entries_for_snapshot "$snap"
 	jq -r --arg kv "$kv" '
 	  .[] | select(.linux? != null)
-		  | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+		  # accept both: openSUSE-<kv>-<ksum>.efi and openSUSE-<kv>-<ksum>-<isum>.efi
+		  | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}(?:-[0-9a-f]{40})?\\.efi$"))
 		  | [ .id, .linux, '"${jq_effective_cmdline}"', (.title // .showTitle // "") ] | @tsv
 	' < "$entryfile" | head -n1
 }

--- a/sdbootutil
+++ b/sdbootutil
@@ -526,7 +526,7 @@ uki_uname() {
 		printf '%s' "${uki_uname_cache[$path]}"; return
 	fi
 	local kv=""
-	# Try JSON first (works with both full and --section outputs)
+	# Try JSON first
 	kv="$(ukify inspect --section=.uname --json "$path" 2>/dev/null \
 		  | jq -r 'first( (.. | objects | select(.name?==".uname") | .text?) ) // ""')"
 	if [[ -z "$kv" ]]; then
@@ -818,7 +818,7 @@ reuse_initrd()
 	ker_chksum="$chksum"
 
 	[ -z "$arg_no_reuse_initrd" ] || return 1
-	settle_entry_token "${snapshot}"+
+	settle_entry_token "${snapshot}"
 
 	# Check if in our UKI build dir is our initrd
 	if [ -n "$use_uki" ]; then
@@ -1213,7 +1213,7 @@ install_kernel()
 
 	info "Installing kernel $kernel_version"
 	dbg_var "snapshot"
-	
+
 	calc_chksum "$src"
 	ker_chksum="$chksum"
 	settle_entry_token "${snapshot}"
@@ -1712,7 +1712,8 @@ update_entry_conf()
 	cp "$tmpdir/entry.conf" "$conf"
 }
 
-update_entry() {
+update_entry()
+{
 	local snapshot="$1"
 	local kernel_version="$2"
 
@@ -1740,7 +1741,8 @@ update_entry() {
 	warn "No entry found to update for kernel $kernel_version (snapshot $snapshot)"
 }
 
-update_all_entries() {
+update_all_entries()
+{
 	local snapshot="$1"
 	make_free_space "$snapshot" 1024
 
@@ -1767,6 +1769,7 @@ update_all_entries() {
 		fi
 	done < <(jq -r '.[] | .linux? // empty' < "$entryfile")
 
+	# This action will require to update the PCR predictions
 	update_predictions=1
 }
 
@@ -1821,7 +1824,8 @@ declare -A installed_kernels
 # Map of ESP path to id of kernels that are not in the subvol
 declare -A stale_kernels
 is_bootable=
-update_kernels() {
+update_kernels()
+{
 	local snapshot="$1"
 	local path id sum
 	installed_kernels=()
@@ -1868,7 +1872,8 @@ kv_from_path() {
 	esac
 }
 
-list_kernels() {
+list_kernels()
+{
 	local snapshot=""
 	[ -z "$have_snapshots" ] || snapshot="${1:?}"
 
@@ -1907,7 +1912,6 @@ list_kernels() {
 		printf "${color_red}stale %s${color_end}\n" "${stale_kernels[$k]}"
 	done
 }
-
 
 list_devices()
 {
@@ -2356,7 +2360,8 @@ set_default_grub2_bls()
 	grubenv_set "default" "$id"
 }
 
-set_default_entry() {
+set_default_entry()
+{
 	local id="${1:?}"
 
 	info "Setting default entry $id"
@@ -2501,7 +2506,8 @@ is_type2_id() {
 	[[ "$1" =~ \.efi@[0-9]+$ ]]
 }
 
-set_default_snapshot() {
+set_default_snapshot()
+{
 	[ -n "$have_snapshots" ] || { info "System does not support snapshots."; return 0; }
 	local num="${1:?}"
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -666,7 +666,7 @@ remove_uki()
 	if [ "${#remaining_profiles[@]}" -gt 0 ]; then
 		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
 		local out="$tmpdir/uki-${kernel_version}.efi"
-		build_uki_image "$kernel_version" "$ker_chksum" "$out"
+		build_uki_image "$kernel_version" "$ker_chksum" "$out" "$snapshot"
 		make_free_space_for_uki "$snapshot" "$out" || err "No free space for rebuilt UKI"
 		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
 		rm -f "$out"
@@ -1277,7 +1277,7 @@ install_kernel()
 
 		# Build the combined UKI
 		local out="$tmpdir/uki-${kernel_version}.efi"
-		build_uki_image "$kernel_version" "$ker_chksum" "$out"
+		build_uki_image "$kernel_version" "$ker_chksum" "$out" "$snapshot"
 		make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for new UKI"
 		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
 		rm -f "$out"
@@ -1617,7 +1617,7 @@ update_uki_profile()
 
 	local out="$tmpdir/uki-${kv}.efi"
 	info "Rebuilding UKI image for kernel $kv"
-	build_uki_image "$kv" "$sum" "$out"
+	build_uki_image "$kv" "$sum" "$out" "$snapshot"
 	make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for rebuilt UKI"
 	install_with_rollback "$out" "$boot_root/EFI/Linux/openSUSE-${kv}-${sum}.efi" || err "Failed to install rebuilt UKI"
 	rm -f "$out"
@@ -2395,13 +2395,120 @@ kernel_sum_for_snapshot()
 	echo "$chksum"
 }
 
+extract_running_snapshot_id()
+{
+	sed -nE 's/.*rootflags=subvol=(@\/)?([^ ]*\/)?\.snapshots\/([0-9]+)\/snapshot.*/\3/p' /proc/cmdline \
+	| head -n1 || true
+}
+
+select_profiles_for_uki()
+{
+	local snap="${1:?}"
+	local dir="${2:?}"
+
+	shopt -s nullglob
+	local profiles=( "$dir"/profile-*.efi )
+	shopt -u nullglob
+	[ "${#profiles[@]}" -gt 0 ] || return 0
+
+	local protected_re
+	protected_re="$(regex_snapshot_ids_for_free_space "$snap")"
+
+	local running_sid
+	running_sid="$(extract_running_snapshot_id || true)"
+
+	# Build JSON for available profiles from filenames
+	local profiles_json
+	profiles_json="$(
+		printf '%s\n' "${profiles[@]}" | jq -R '
+		  select(test("/profile-[0-9]+\\.efi$"))
+		  | {file: ., sid: (capture("/profile-(?<sid>[0-9]+)\\.efi$").sid | tonumber)}
+		' | jq -s '.'
+	)"
+
+	local bootctl_json
+	bootctl_json="$(bootctl list --json=short 2>/dev/null)"
+	: "${bootctl_json:='[]'}"
+
+	local prot_json
+	prot_json="$(
+		jq -n \
+		   --arg run "${running_sid:-}" \
+		   --argjson boot "$bootctl_json" '
+		  def sid_from_opts($s):
+			($s // "")
+			| capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>[0-9]+)/snapshot")?
+			| .sid? // empty
+			| tonumber;
+
+		  [
+			($run | select(. != "") | tonumber)?,
+			($boot[]? | select(.isDefault == true or .isSelected == true)
+			  | sid_from_opts((.options // .cmdline))
+			)?
+		  ]
+		  | map(select(. != null))
+		  | unique
+		'
+	)"
+
+	# Decide which profiles to keep (max 8). Prefer protected; then newest SIDs.
+	jq -rn --arg re "$protected_re" \
+			 --argjson profiles "$profiles_json" \
+			 --argjson prot "$prot_json" '
+		$profiles
+		| map(. as $p
+			| $p + {
+				protected: (
+				  ($p.sid | tostring | test("^" + $re + "$"))
+				  or
+				  (($prot | index($p.sid)) != null)
+				),
+				prio: $p.sid
+			  }
+		  )
+		| ( [ .[] | select(.protected) ] | sort_by(.prio) | reverse ) as $keep_prot
+		| ( [ .[] | select(.protected | not) ] | sort_by(.prio) | reverse ) as $keep_rest
+		| ($keep_prot + $keep_rest)[:8]
+		| .[] | .file
+	'
+}
+
 ukify_collect_args()
 {
 	local dir="${1:?}"
+	local snapshot="${2:?}"
 	shopt -s nullglob
 	local f
+
 	for f in "${dir}"/initrd-*; do [ -f "$f" ] && echo "--initrd=$f"; done
-	for f in "${dir}"/profile-*.efi; do [ -f "$f" ] && echo "--join-profile=$f"; done
+
+	mapfile -t uki_keep < <(select_profiles_for_uki "${snapshot:-${arg_default_snapshot:-0}}" "$dir")
+
+	declare -A keep_map=()
+	for f in "${uki_keep[@]}"; do keep_map["$f"]=1; done
+
+	local all_profiles=( "$dir"/profile-*.efi )
+	local dropped_profiles=()
+	local dropped_snapshots=()
+
+	for f in "${all_profiles[@]}"; do
+		if [ -f "$f" ] && [ -z "${keep_map["$f"]}" ]; then
+			dropped_profiles+=( "$f" )
+			local b; b="$(basename -- "$f")"
+			if [[ "$b" =~ ^profile-([0-9]+)\.efi$ ]]; then
+				dropped_snapshots+=( "${BASH_REMATCH[1]}" )
+			fi
+		fi
+	done
+
+	if [ "${#dropped_profiles[@]}" -gt 0 ]; then
+		warn "Dropping UKI profiles for snapshots: ${dropped_snapshots[*]}"
+		for f in "${dropped_profiles[@]}"; do rm -f -- "$f"; done
+	fi
+
+	for f in "${uki_keep[@]}"; do [ -f "$f" ] && echo "--join-profile=$f"; done
+
 	shopt -u nullglob
 }
 
@@ -2424,12 +2531,12 @@ build_uki_profile()
 
 build_uki_image()
 {
-	local kv="${1:?}" sum="${2:?}" out="${3:?}"
+	local kv="${1:?}" sum="${2:?}" out="${3:?}" snapshot="${4:?}"
 	local dir; dir="$(build_uki_workdir "$kv" "$sum")"
 	local linux_src="${dir}/${image}"
 	[ -f "$linux_src" ] || err "Missing ${linux_src} (kernel copy not staged)."
 
-	mapfile -t extra < <(ukify_collect_args "$dir")
+	mapfile -t extra < <(ukify_collect_args "$dir" "$snapshot")
 	ukify build --linux="$linux_src" --output="$out" "${extra[@]}"
 }
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -2217,6 +2217,91 @@ loader_conf_get()
 	fi
 }
 
+default_kernel_version_from_id() {
+	local id="$1"
+	local kv=
+
+	# UKI id example:
+	#   openSUSE-6.16.0-1-default-f89b6e7...efi@1
+	if [[ "$id" =~ ^openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi@ ]]; then
+		kv="${BASH_REMATCH[1]}"
+		echo "$kv"
+		return 0
+	fi
+
+	# Type1/BLS id examples:
+	#   opensuse-tumbleweed-6.16.0-1-default-1.conf
+	#   system-opensuse-tumbleweed-6.16.0-1-default-1+3.conf
+	# General form: <prefix>-<kv>-<snap>[+tries].conf
+	# Extract <kv> as the part between the last-but-one '-' sequence(s) and '-<snap>'
+	# We'll search for "-<snap>" and strip everything after; then take the last '-' chunk as snapshot,
+	# leaving "...-<kv>" before that and isolate <kv>.
+	if [[ "$id" =~ ^[^@]+$ ]]; then
+		local base="${id%.conf}"
+		base="${base%%+*}"                  # drop +tries
+		local head="${base%-[0-9]*}"        # strip -<snap>
+		# head ends in "...-<kv>"; but <kv> itself contains dashes.
+		# Try to capture last 3 dash groups (x-y-z) like "6.16.0-1-default"
+		if [[ "$head" =~ ([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[^-]+)$ ]]; then
+			kv="${BASH_REMATCH[1]}"
+			echo "$kv"
+			return 0
+		fi
+	fi
+
+	echo ""
+}
+
+pick_entry_id_for_snapshot() {
+	local snapshot="$1"
+
+	# Read current default first (this may overwrite $entryfile)
+	local default_id default_kv
+	default_id="$(get_default_entry || true)"
+	default_kv="$(default_kernel_version_from_id "$default_id")"
+
+	# (re)filter entries strictly to this snapshot
+	update_entries_for_snapshot "$snapshot"
+
+	# Prefer same kernel version as current default, but only for @<snapshot>
+	local candidate=
+	if [ -n "$default_kv" ]; then
+		candidate="$(
+			jq -r --arg kv "$default_kv" --arg snap "$snapshot" '
+			  .[]
+			  | select(.linux? != null)
+			  | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+			  | select(.id | endswith("@" + $snap))
+			  | .id
+			' < "$entryfile" | head -n1
+		)"
+	fi
+
+	# Otherwise: take the first UKI for this snapshot
+	if [ -z "$candidate" ]; then
+		candidate="$(
+			jq -r --arg snap "$snapshot" '
+			  .[]
+			  | select(.linux? != null)
+			  | select(.linux | test("^/EFI/Linux/openSUSE-.*-[0-9a-f]{40}\\.efi$"))
+			  | select(.id | endswith("@" + $snap))
+			  | .id
+			' < "$entryfile" | head -n1
+		)"
+	fi
+
+	# Fallback: any entry for this snapshot
+	if [ -z "$candidate" ]; then
+		candidate="$(
+			jq -r --arg snap "$snapshot" '
+			  .[] | select(.id | endswith("@" + $snap)) | .id
+			' < "$entryfile" | head -n1
+		)"
+	fi
+
+	[ -n "$candidate" ] && echo "$candidate"
+}
+
 grubenv_set()
 {
 	local key="${1:?}"
@@ -2271,15 +2356,21 @@ set_default_grub2_bls()
 	grubenv_set "default" "$id"
 }
 
-set_default_entry()
-{
+set_default_entry() {
 	local id="${1:?}"
 
 	info "Setting default entry $id"
 
-	if [ ! -f "${boot_root}/loader/entries/$id" ] && [ ! -f "${boot_root}/loader/entries/$id.conf" ]; then
-		err "Boot loader entry $id not found"
+	if is_type2_id "$id"; then
+		# Type #2 (UKI): validate via bootctl entries, not filesystem
+		entry_id_exists "$id" || err "Boot loader entry $id not found among loader entries"
+	else
+		# Type #1 (BLS): validate by presence of the .conf file
+		if [ ! -f "${boot_root}/loader/entries/$id" ] && [ ! -f "${boot_root}/loader/entries/$id.conf" ]; then
+			err "Boot loader entry $id not found"
+		fi
 	fi
+
 	if is_sdboot; then
 		set_default_sdboot "$id"
 	elif is_grub2_bls; then
@@ -2395,26 +2486,39 @@ get_timeout()
 	fi
 }
 
-set_default_snapshot()
-{
+entry_id_exists() {
+	local id="${1:?}"
+	local saved="$entryfile"
+	update_entries_for_this_system
+	local ok
+	ok=$(jq -r '.[].id' < "$entryfile" | grep -Fx -- "$id" || true)
+	[ -n "$ok" ]
+	entryfile="$saved"
+}
+
+is_type2_id() {
+	# UKI ids look like: openSUSE-<kv>-<sha40>.efi@<profile-id>
+	[[ "$1" =~ \.efi@[0-9]+$ ]]
+}
+
+set_default_snapshot() {
 	[ -n "$have_snapshots" ] || { info "System does not support snapshots."; return 0; }
 	local num="${1:?}"
-	local configs
 
 	info "Setting default snapshot $num"
 
 	update_entries_for_snapshot "$num"
-	mapfile configs < <(jq '.[]|[.id]|join(" ")' -r < "$entryfile")
-	configs=("${configs[@]%$nl}")
-	if [ -z "${configs[0]}" ]; then
-		info "Snapshot $num has no configs, trying to create them..."
+
+	# Try to pick a best entry id (UKI preferred, same kv as current default if possible)
+	local id
+	id="$(pick_entry_id_for_snapshot "$num" || true)"
+
+	if [ -z "$id" ]; then
+		info "Snapshot $num has no boot entries, trying to create them..."
 		install_all_kernels "$num"
 		update_entries_for_snapshot "$num"
-		mapfile configs < <(jq '.[]|[.id]|join(" ")' -r < "$entryfile")
-		configs=("${configs[@]%$nl}")
-		if [ -z "${configs[0]}" ]; then
-			err "snapshot $num has no kernels"
-		fi
+		id="$(pick_entry_id_for_snapshot "$num" || true)"
+		[ -n "$id" ] || err "snapshot $num has no kernels"
 	fi
 
 	# The default snapshot is not the criteria used for the
@@ -2429,7 +2533,7 @@ set_default_snapshot()
 	btrfs subvolume set-default "${subvolume_id}" /.snapshots
 	rm -f "$snapperfile"
 
-	set_default_entry "${configs[0]}"
+	set_default_entry "$id"
 }
 
 have_pcrlock()

--- a/sdbootutil
+++ b/sdbootutil
@@ -307,6 +307,14 @@ is_secure_boot()
 	grep -q $'\x01' /sys/firmware/efi/efivars/SecureBoot-8be4df61-93ca-11d2-aa0d-00e098032b8c
 }
 
+use_uki()
+{
+	if [ "$UNIFIED_KERNEL_IMAGE" == "yes" ]; then
+		return
+	fi
+	return 1
+}
+
 is_sdboot()
 {
 	local sdboot grub2_bls
@@ -489,21 +497,44 @@ update_entries()
 
 update_entries_for_subvol()
 {
-	local subvol="$1"
+	local subvol="${1:?}"
 	local ext="${2:-}"
 
-	[ -z "$ext" ] || ext="|$ext"
-	# Look at .options (BLS #1) OR .cmdline (UKI auto-entry)
-	update_entries jq "[.[] \
-	  | select(has(\"options\") or has(\"cmdline\")) \
-	  | select((.options // .cmdline) \
-	  | test(\"root=(?:UUID=$root_uuid|$root_device) .*rootflags=subvol=$subvol\")$ext)]"
+	# Try to extract the snapshot number from the subvol path
+	local snap=
+	snap="$(printf '%s\n' "$subvol" | sed -n 's@.*/\.snapshots/\([0-9]\+\)/snapshot$@\1@p')"
+
+	[ -n "$snap" ] || err "No snapshot number detected!"
+	update_entries_for_snapshot "$snap" "$ext"
 }
 
 update_entries_for_snapshot()
 {
-	local n="$1"
-	update_entries_for_subvol "${subvol_prefix}/.snapshots/$n/snapshot"
+	local n="${1:?}"
+	local ext="${2:-}"
+
+	# shellcheck disable=SC2016
+	update_entries jq \
+	  --arg snap "$n" \
+	  --arg root_uuid "$root_uuid" \
+	  --arg root_device "$root_device" '
+	  [ .[]
+		| select(has("options") or has("cmdline"))
+		| (
+			(.options? // .cmdline? // "")
+		  ) as $cmd
+		| select(
+			($cmd | test("(^| )root=(?:UUID=" + $root_uuid + "|" + $root_device + ")( |$)"))
+			and
+			($cmd | test("(^| )rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/" + $snap + "/snapshot( |$)"))
+		  )
+	  ]'
+
+	# If caller provided an extra filter, apply it in a second pass
+	if [ -n "$ext" ]; then
+		tmp="$(mktemp -t sdbootutil.entries.XXXXXX)"
+		jq "${ext}" < "$entryfile" > "$tmp" && mv "$tmp" "$entryfile"
+	fi
 }
 
 update_entries_for_snapshot_invert()
@@ -517,25 +548,6 @@ update_entries_for_this_system()
 	update_entries jq "[.[] \
 	  | select(has(\"options\") or has(\"cmdline\")) \
 	  | select((.options // .cmdline) | test(\"root=(?:UUID=$root_uuid|$root_device)\"))]"
-}
-
-declare -A uki_uname_cache
-uki_uname() {
-	local path="${1:?}"
-	if [[ -n "${uki_uname_cache[$path]+x}" ]]; then
-		printf '%s' "${uki_uname_cache[$path]}"; return
-	fi
-	local kv=""
-	# Try JSON first
-	kv="$(ukify inspect --section=.uname --json "$path" 2>/dev/null \
-		  | jq -r 'first( (.. | objects | select(.name?==".uname") | .text?) ) // ""')"
-	if [[ -z "$kv" ]]; then
-		# Plain-text fallback: read the line after "text:" within .uname section
-		kv="$(ukify inspect "$path" 2>/dev/null \
-			  | awk '$1==".uname:"{f=1;next} f&&$1=="text:"{getline; sub(/^[[:space:]]+/,""); print; exit}')"
-	fi
-	uki_uname_cache[$path]="$kv"
-	printf '%s' "$kv"
 }
 
 entry_conf_file()
@@ -625,6 +637,74 @@ settle_entry_token()
 	return 0
 }
 
+remove_uki()
+{
+	local snapshot="${1:?}"
+	local kernel_version="${2:?}"
+	local ker_chksum="${3:-}"
+
+	# Compute sum if not provided
+	if [ -z "$ker_chksum" ]; then
+		ker_chksum="$(kernel_sum_for_snapshot "$snapshot" "$kernel_version")"
+	fi
+
+	local work; work="$(build_uki_workdir "$kernel_version" "$ker_chksum")"
+	local prof="$work/profile-${snapshot}.efi"
+	local linuxdir="$boot_root/EFI/Linux"
+
+	if [ -f "$prof" ]; then
+		info "Deleting profile for snapshot $snapshot"
+		rm -f "$prof"
+	else
+		warn "Profile for snapshot $snapshot not found; skipping delete"
+	fi
+
+	shopt -s nullglob
+	local remaining_profiles=( "$work"/profile-*.efi )
+	shopt -u nullglob
+
+	if [ "${#remaining_profiles[@]}" -gt 0 ]; then
+		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
+		local out="$tmpdir/uki-${kernel_version}.efi"
+		build_uki_image "$kernel_version" "$ker_chksum" "$out"
+		make_free_space_for_uki "$snapshot" "$out" || err "No free space for rebuilt UKI"
+		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
+		rm -f "$out"
+		[ -z "$failed" ] || err "Failed to install $failed"
+		reset_rollback
+	else
+		info "No snapshots left for $kernel_version; removing all artifacts"
+		rm -rf "$work"
+		rm -f "$linuxdir/openSUSE-${kernel_version}-"*.efi
+	fi
+
+	update_predictions=1
+}
+
+remove_kernel()
+{
+	local snapshot="$1"
+	local kernel_version="$2"
+	[ -n "$kernel_version" ] || err "Missing kernel version"
+
+	info "Removing kernel $kernel_version"
+	dbg_var "snapshot"
+
+	if use_uki; then
+		remove_uki "$snapshot" "$kernel_version"
+		return
+	fi
+
+	settle_entry_token "${snapshot}"
+	local id
+	id="$(entry_conf_file "$kernel_version" "$snapshot")"
+	info "Removing boot entry $id"
+	bootctl unlink "$id"
+
+	# This action will require to update the PCR predictions
+	update_predictions=1
+}
+
 install_with_rollback()
 {
 	local src="${1:?}"
@@ -641,99 +721,6 @@ install_with_rollback()
 	install -p -m 0644 "$src" "$dst" || return "$?"
 	chown root:root "$dst" 2>/dev/null || :
 	info "Installed $dst"
-}
-
-remove_uki()
-{
-	local snapshot="$1"
-	local kernel_version="$2"
-	local ker_chksum="$3"
-	local linuxdir="$boot_root/EFI/Linux"
-	
-	subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
-	if [ -z "$ker_chksum" ]; then
-		local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
-		calc_chksum "$src"
-		ker_chksum="$chksum"
-	fi
-
-	# Remove this snapshot's profile
-	local dir="${ukidir}/${kernel_version}-${ker_chksum}"
-	local prof="$dir/profile-${snapshot}.efi"
-	dbg "Profile path: $prof"
-	if [ -f "$prof" ]; then
-		info "Deleting profile for snapshot $snapshot"
-		rm -f "$prof"
-	else
-		warn "Profile for snapshot $snapshot not found; skipping delete"
-	fi
-
-	# Rebuild or purge UKI
-	shopt -s nullglob
-	# gather remaining profiles
-	local remaining_profiles=( "$dir"/profile-*.efi )
-	shopt -u nullglob
-
-	if [ "${#remaining_profiles[@]}" -gt 0 ]; then
-		# still have other profiles --> rebuild UKI
-		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
-		local tmp_uki="$tmpdir/uki-${kernel_version}.efi"
-		local ukify_args=(
-			--linux="${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
-			--output="$tmp_uki"
-		)
-		# add all initrds
-		for initrd in "$dir"/initrd-*; do
-			[ -f "$initrd" ] || continue
-			ukify_args+=(--initrd="$initrd")
-		done
-		# add all remaining profiles
-		for p in "${remaining_profiles[@]}"; do
-			ukify_args+=(--join-profile="$p")
-		done
-
-		ukify build "${ukify_args[@]}"
-		make_free_space_for_uki "$snapshot" "$tmp_uki" || err "No free space in $boot_root for new UKI"
-		install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi"  || failed="UKI"
-		rm -f "$tmp_uki"
-
-		[ -z "$failed" ] || err "Failed to install $failed"
-		reset_rollback
-
-	else
-		# no profiles left --> remove entire kernel dir + UKI file
-		info "No snapshots left for $kernel_version; removing all artifacts"
-		rm -rf "$dir"
-		# remove the on-disk UKI(s)
-		rm -f "$linuxdir/openSUSE-${kernel_version}-"*.efi
-	fi
-
-	# This action will require to update the PCR predictions
-	update_predictions=1
-}
-
-remove_kernel()
-{
-	local snapshot="$1"
-	local kernel_version="$2"
-	[ -n "$kernel_version" ] || err "Missing kernel version"
-
-	info "Removing kernel $kernel_version"
-	dbg_var "snapshot"
-
-	if [ -n "$use_uki" ]; then
-		remove_uki "$snapshot" "$kernel_version"
-		return
-	fi
-
-	settle_entry_token "${snapshot}"
-	local id
-	id="$(entry_conf_file "$kernel_version" "$snapshot")"
-	info "Removing boot entry $id"
-	bootctl unlink "$id"
-
-	# This action will require to update the PCR predictions
-	update_predictions=1
 }
 
 update_snapper()
@@ -821,7 +808,7 @@ reuse_initrd()
 	settle_entry_token "${snapshot}"
 
 	# Check if in our UKI build dir is our initrd
-	if [ -n "$use_uki" ]; then
+	if use_uki; then
 		[ -f "${ukidir}/${kernel_version}-${ker_chksum}/initrd-0" ]
 		return $?
 	fi
@@ -856,17 +843,11 @@ reuse_initrd()
 
 reuse_profile()
 {
-	local snapshot="$1"
-	local kernel_version="${2:?}"
-	subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
-	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
-	calc_chksum "$src"
-	ker_chksum="$chksum"
+	local snapshot="${1:?}" kernel_version="${2:?}"
 
 	[ -z "$arg_no_reuse_profile" ] || return 1
-
-	# Check if a profile already exists for the snapshot
-	[ -f "${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi" ]
+	local sum; sum="$(kernel_sum_for_snapshot "$snapshot" "$kernel_version")"
+	[ -f "$(build_uki_workdir "$kernel_version" "$sum")/profile-${snapshot}.efi" ]
 }
 
 mount_chroot()
@@ -1187,7 +1168,8 @@ make_free_space_for_uki()
 	[ "$total_size" -lt "$free_space" ]
 }
 
-create_boot_options() {
+create_boot_options()
+{
 	local subvol="$1"
 	local boot_options=
 	for i in "${subvol:1}/etc/kernel/cmdline" "${subvol:1}/usr/lib/kernel/cmdline" /proc/cmdline; do
@@ -1223,8 +1205,6 @@ install_kernel()
 	local initrd="${src%/*}/initrd"
 
 	mkdir -p "$boot_root${dst%/*}"
-	[ -z "$use_uki" ] || mkdir -p "$linuxdir"
-	[ -z "$use_uki" ] || mkdir -p "${ukidir}/${kernel_version}-${ker_chksum}"
 
 	if [ -e "$initrd" ]; then
 		ln -s "$initrd" "$tmpdir/initrd-0"
@@ -1278,53 +1258,31 @@ install_kernel()
 		add_kernel_version_to_title
 	fi
 
-	if [ -n "$use_uki" ]; then
-		if [ -e "$tmpdir/initrd-0" ]; then
-			i=0
-			while [ -e "$tmpdir/initrd-$i" ]; do
-				install_with_rollback "$tmpdir/initrd-$i" "${ukidir}/${kernel_version}-${ker_chksum}/initrd-$i" || { failed=initrd; break; }
-				rm -f "$tmpdir/initrd-$i"
-				((++i))
-			done
-		fi
+	if use_uki; then
+		# Copy initrds into workdir
+		local i=0 work; work="$(build_uki_workdir "$kernel_version" "$ker_chksum")"
+		while [ -e "$tmpdir/initrd-$i" ]; do
+			install_with_rollback "$tmpdir/initrd-$i" "$work/initrd-$i" || { failed=initrd; break; }
+			rm -f "$tmpdir/initrd-$i"
+			((++i))
+		done
+		ensure_image_in_workdir "$snapshot" "$kernel_version" "$ker_chksum"
 
-		[ -f "${ukidir}/${kernel_version}-${ker_chksum}"/"$image" ] || cp "${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image" "${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
-
-		local ukify_args=(
-			--linux="${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
-			--output="$tmpdir/uki-${kernel_version}.efi"
-		)
+		# Create/refresh this snapshot's profile if missing or --no-reuse-profile
 		if ! reuse_profile "$snapshot" "$kernel_version"; then
-			info "Building UKI profile for snapshot $snapshot"
-			ukify build \
-			  --profile="TITLE=${title}${snapshot:+${nl}ID=$snapshot}" \
-			  --cmdline="$boot_options" \
-			  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
+			build_uki_profile "$snapshot" "$kernel_version" "$ker_chksum" "$boot_options"
 		else
 			info "Found existing UKI profile for snapshot $snapshot"
 		fi
-		info "Building UKI for kernel $kernel_version"
-		shopt -s nullglob
-		for initrd in "${ukidir}/${kernel_version}-${ker_chksum}"/initrd-*; do
-			[ -f "$initrd" ] || continue
-			ukify_args+=(--initrd="$initrd")
-		done
-		for prof in "${ukidir}/${kernel_version}-${ker_chksum}"/profile-*.efi; do
-			[ -f "$prof" ] || continue
-			ukify_args+=(--join-profile="$prof")
-		done
-		shopt -u nullglob
-		ukify build "${ukify_args[@]}"
 
-		make_free_space_for_uki "$snapshot" "$tmpdir/uki-${kernel_version}.efi" || err "No free space in $boot_root for new UKI"
-
-		install_with_rollback "$tmpdir/uki-${kernel_version}.efi" "$linuxdir/openSUSE-$kernel_version-$chksum.efi" || failed="UKI"
-		rm -f "$tmpdir/uki-${kernel_version}.efi"
-
+		# Build the combined UKI
+		local out="$tmpdir/uki-${kernel_version}.efi"
+		build_uki_image "$kernel_version" "$ker_chksum" "$out"
+		make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for new UKI"
+		install_with_rollback "$out" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi" || failed="UKI"
+		rm -f "$out"
 		[ -z "$failed" ] || err "Failed to install $failed"
 		reset_rollback
-
-		# This action will require to update the PCR predictions
 		update_predictions=1
 		return
 	fi
@@ -1449,7 +1407,7 @@ cleanup_entries()
 			continue
 		fi
 
-		kv="$(uki_uname "$boot_root$_linux")"
+		kv="$(kv_from_any "$_linux"  "$_snap")"
 		if [ -z "$kv" ]; then
 			dbg "No .uname in $_linux; skipping"
 			continue
@@ -1555,7 +1513,8 @@ list_entries()
 	done < <(jq '.[]|[.isDefault, if has("isReported") then .isReported else 0 end, if has("type") then .type else "unknown" end, .id, .root, .path, .showTitle]|join(" ")' -r < "$entryfile")
 }
 
-show_entry_fields() {
+show_entry_fields()
+{
 	local snapshot="$1"
 	local kernel_version="${2:?Missing kernel version}"
 	settle_entry_token "${snapshot}"
@@ -1599,7 +1558,8 @@ show_entry_fields() {
 	[ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
 
 	# Helper respecting --keys filtering
-	print_kv() {
+	print_kv()
+	{
 		local k="$1" v="$2"
 		if [ "${#arg_entry_keys[@]}" -eq 0 ] || [[ ${arg_entry_keys[*]} == *"all"* ]] || [[ ${arg_entry_keys[*]} == *"$k"* ]]; then
 			echo -e "$k\t$v"
@@ -1615,7 +1575,8 @@ show_entry_fields() {
 	print_kv initrd  "(embedded)"
 }
 
-find_uki_for_snapshot() {
+find_uki_for_snapshot()
+{
 	local snapshot="$1"
 	local kernel_version="$2"
 
@@ -1634,65 +1595,35 @@ find_uki_for_snapshot() {
 	' < "$entryfile" | head -n1
 }
 
-update_uki_entry_conf() {
-	local snapshot="$1"
-	local kernel_version="$2"
+update_uki_profile()
+{
+	local snapshot="${1:?}" kv="${2:?}"
 
-	# Locate matching UKI in entries.json
 	local entry_id linux_path old_opts title
-	IFS=$'\t' read -r entry_id linux_path old_opts title < <(find_uki_for_snapshot "$snapshot" "$kernel_version")
-	[ -n "$linux_path" ] || err "No UKI entry for kernel $kernel_version that matches snapshot $snapshot."
+	IFS=$'\t' read -r entry_id linux_path old_opts title < <(find_uki_entry "$snapshot" "$kv")
+	[ -n "$linux_path" ] || err "No UKI entry for kernel $kv that matches snapshot $snapshot."
 	[ -f "$boot_root$linux_path" ] || err "UKI not found on ESP: $boot_root$linux_path"
 
-	# Compute subvol & new cmdline
-	local subvol=""
-	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
-	local boot_options
-	boot_options="$(create_boot_options "$subvol")"
+	# Derive kv/sum & ensure linux staged in workdir
+	local _kv sum; read -r _kv sum < <(uki_sum_from_path "$linux_path")
+	local work; work="$(build_uki_workdir "$kv" "$sum")"
+	[ -d "$work" ] || err "UKI working dir not found: $work"
 
-	# Title: prefer the one from entries.json, else fall back
-	local effective_title="${title:-${os_release_PRETTY_NAME:-Linux $kernel_version}}"
+	local subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	local boot_options; boot_options="$(create_boot_options "$subvol")"
 
-	# Derive checksum from filename (…/openSUSE-<kv>-<sum>.efi)
-	local fname sum kvdir ukidir_kv linuxdir
-	fname="${linux_path##*/}"
-	sum="${fname%.efi}"
-	sum="${sum#openSUSE-$kernel_version-}"
-	linuxdir="$boot_root/EFI/Linux"
-	ukidir_kv="${ukidir}/${kernel_version}-${sum}"
+	info "Updating UKI profile for snapshot $snapshot (kernel $kv)"
+	build_uki_profile "$snapshot" "$kv" "$sum" "$boot_options"
 
-	[ -d "$ukidir_kv" ] || err "UKI working dir not found: $ukidir_kv (kernel $kernel_version, sum $sum)."
-
-	# (Re)build this snapshot's profile
-	info "Updating UKI profile for snapshot $snapshot (kernel $kernel_version)"
-	ukify build \
-		--profile="TITLE=${effective_title}${nl}ID=${snapshot}" \
-		--cmdline="$boot_options" \
-		--output="${ukidir_kv}/profile-${snapshot}.efi"
-
-	# Rebuild the UKI joining ALL initrds and ALL profile-*.efi that still exist
-	local tmp_uki="$tmpdir/uki-${kernel_version}.efi"
-	local ukify_args=( --linux="${ukidir_kv}/${image}" --output="$tmp_uki" )
-
-	shopt -s nullglob
-	local f
-	for f in "${ukidir_kv}"/initrd-*; do
-		[ -f "$f" ] && ukify_args+=( --initrd="$f" )
-	done
-	for f in "${ukidir_kv}"/profile-*.efi; do
-		[ -f "$f" ] && ukify_args+=( --join-profile="$f" )
-	done
-	shopt -u nullglob
-
-	info "Rebuilding UKI image for kernel $kernel_version"
-	ukify build "${ukify_args[@]}"
-
-	make_free_space_for_uki "$snapshot" "$tmp_uki" || err "No free space in $boot_root for rebuilt UKI"
-	install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-${kernel_version}-${sum}.efi" || err "Failed to install rebuilt UKI"
-	rm -f "$tmp_uki"
+	local out="$tmpdir/uki-${kv}.efi"
+	info "Rebuilding UKI image for kernel $kv"
+	build_uki_image "$kv" "$sum" "$out"
+	make_free_space_for_uki "$snapshot" "$out" || err "No free space in $boot_root for rebuilt UKI"
+	install_with_rollback "$out" "$boot_root/EFI/Linux/openSUSE-${kv}-${sum}.efi" || err "Failed to install rebuilt UKI"
+	rm -f "$out"
 	reset_rollback
 
-	# Predictors need refresh
+	# This action will require to update the PCR predictions
 	update_predictions=1
 }
 
@@ -1732,9 +1663,9 @@ update_entry()
 	fi
 
 	# UKI path
-	if [ -n "${use_uki:-1}" ]; then
+	if use_uki; then
 		info "Updating UKI entry for kernel $kernel_version (snapshot $snapshot)"
-		update_uki_entry_conf "$snapshot" "$kernel_version"
+		update_uki_profile "$snapshot" "$kernel_version"
 		return
 	fi
 
@@ -1743,29 +1674,25 @@ update_entry()
 
 update_all_entries()
 {
-	local snapshot="$1"
+	local snapshot="${1:?}"
 	make_free_space "$snapshot" 1024
 
 	update_entries_for_snapshot "$snapshot"
 
-	# Update classic BLS entries (have .path that is a *.conf on disk)
+	# Type #1 (BLS) updates
 	while read -r conf; do
 		[ -f "$conf" ] || continue
 		update_entry_conf "$conf" "$snapshot"
 	done < <(jq -r '.[] | select(.path? != null) | .path' < "$entryfile")
 
-	# Update UKI entries (have .linux pointing to /EFI/Linux/openSUSE-<kv>-<sum>.efi)
-	# Extract kernel version from the filename and rebuild each once.
-	local kvs_seen=()
+	# Type #2 (UKI) updates — dedupe by kv
+	local seen=()
 	while read -r linux_path; do
 		[ -n "$linux_path" ] || continue
-		local base kv
-		base="${linux_path##*/}"                 # openSUSE-<kv>-<sum>.efi
-		kv="${base#openSUSE-}"; kv="${kv%-*}"    # strip prefix and trailing -<sum>.efi
-		# de-duplicate kernel versions in case multiple entries point to the same UKI
-		if [[ " ${kvs_seen[*]} " != *" $kv "* ]]; then
-			kvs_seen+=("$kv")
-			update_uki_entry_conf "$snapshot" "$kv"
+		local kv sum; read -r kv sum < <(uki_sum_from_path "$linux_path") || continue
+		if [[ " ${seen[*]} " != *" $kv "* ]]; then
+			seen+=("$kv")
+			update_uki_profile "$snapshot" "$kv"
 		fi
 	done < <(jq -r '.[] | .linux? // empty' < "$entryfile")
 
@@ -1854,24 +1781,6 @@ update_kernels()
 	done < <(jq -r '.[]|select(has("linux"))|[.linux,.id]|join(" ")' < "$entryfile")
 }
 
-kv_from_path() {
-	local p="$1" base
-	case "$p" in
-		# classic BLS: /$entry_token/<kv>/linux-<sha>
-		"/$entry_token/"*"/linux-"*)
-		  base="${p#"/$entry_token/"}"
-		  printf '%s\n' "${base%%/*}"
-		  ;;
-		# UKI: /EFI/Linux/openSUSE-<kv>-<sha>.efi
-		/EFI/Linux/openSUSE-*.efi)
-		  base="${p##*/openSUSE-}"          # <kv>-<sha>.efi
-		  if [[ "$base" =~ ^(.+)-([0-9a-f]{40})\.efi$ ]]; then
-		  	printf '%s\n' "${BASH_REMATCH[1]}"
-		  fi
-		  ;;
-	esac
-}
-
 list_kernels()
 {
 	local snapshot=""
@@ -1886,7 +1795,7 @@ list_kernels()
 	local k id kv
 
 	for k in "${!installed_kernels[@]}"; do
-		kv="$(kv_from_path "$k")"
+		kv="$(kv_from_any "$k" "$snapshot")"
 		[ -n "$kv" ] || continue
 		kv_any_expected["$kv"]=1
 		id="${installed_kernels[$k]}"
@@ -2221,89 +2130,49 @@ loader_conf_get()
 	fi
 }
 
-default_kernel_version_from_id() {
-	local id="$1"
-	local kv=
+# Try to extract <KV> from *any* token:
+#   - BLS path:   /<entry_token>/<KV>/linux-<sha>
+#   - UKI path:   /EFI/Linux/openSUSE-<KV>-<sha>.efi
+#   - UKI id:     openSUSE-<KV>-<sha>.efi[@<snap>]
+#   - BLS id:     *-<KV>-<snap>[+tries].conf
+#   - UKI/BLS basenames work too (see above)
+# Returns KV to stdout; empty string if unknown.
+kv_from_any() {
+	local t="${1:?}"
+	t="${t#/boot/efi}"
+	t="${t#//}"
 
-	# UKI id example:
-	#   openSUSE-6.16.0-1-default-f89b6e7...efi@1
-	if [[ "$id" =~ ^openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi@ ]]; then
-		kv="${BASH_REMATCH[1]}"
-		echo "$kv"
-		return 0
+	# Type1 path: /<token>/<KV>/linux-<sha>
+	if [[ "$t" =~ ^/[^/]+/([^/]+)/linux-[0-9a-f]{40}$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"; return 0
 	fi
 
-	# Type1/BLS id examples:
-	#   opensuse-tumbleweed-6.16.0-1-default-1.conf
-	#   system-opensuse-tumbleweed-6.16.0-1-default-1+3.conf
-	# General form: <prefix>-<kv>-<snap>[+tries].conf
-	# Extract <kv> as the part between the last-but-one '-' sequence(s) and '-<snap>'
-	# We'll search for "-<snap>" and strip everything after; then take the last '-' chunk as snapshot,
-	# leaving "...-<kv>" before that and isolate <kv>.
-	if [[ "$id" =~ ^[^@]+$ ]]; then
-		local base="${id%.conf}"
-		base="${base%%+*}"                  # drop +tries
-		local head="${base%-[0-9]*}"        # strip -<snap>
-		# head ends in "...-<kv>"; but <kv> itself contains dashes.
-		# Try to capture last 3 dash groups (x-y-z) like "6.16.0-1-default"
+	# Type2 path: /EFI/Linux/openSUSE-<KV>-<sha>.efi
+	if [[ "$t" =~ ^/EFI/Linux/openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"; return 0
+	fi
+
+	# Work with just the basename next
+	local base="${t##*/}"
+
+	# UKI id/basename: openSUSE-<KV>-<sha>.efi[@<snap>]
+	if [[ "$base" =~ ^openSUSE-([^-]+-[^-]+-[^-]+)-[0-9a-f]{40}\.efi(@[0-9]+)?$ ]]; then
+		printf '%s\n' "${BASH_REMATCH[1]}"; return 0
+	fi
+
+	# BLS id: *-<KV>-<snap>[+tries].conf
+	if [[ "$base" == *.conf ]]; then
+		local stem="${base%.conf}"
+		stem="${stem%%+*}"               # drop +tries
+		local head="${stem%-[0-9]*}"     # strip trailing -<snap>
 		if [[ "$head" =~ ([0-9]+\.[0-9]+\.[0-9]+-[0-9]+-[^-]+)$ ]]; then
-			kv="${BASH_REMATCH[1]}"
-			echo "$kv"
-			return 0
+			printf '%s\n' "${BASH_REMATCH[1]}"; return 0
 		fi
 	fi
 
-	echo ""
-}
-
-pick_entry_id_for_snapshot() {
-	local snapshot="$1"
-
-	# Read current default first (this may overwrite $entryfile)
-	local default_id default_kv
-	default_id="$(get_default_entry || true)"
-	default_kv="$(default_kernel_version_from_id "$default_id")"
-
-	# (re)filter entries strictly to this snapshot
-	update_entries_for_snapshot "$snapshot"
-
-	# Prefer same kernel version as current default, but only for @<snapshot>
-	local candidate=
-	if [ -n "$default_kv" ]; then
-		candidate="$(
-			jq -r --arg kv "$default_kv" --arg snap "$snapshot" '
-			  .[]
-			  | select(.linux? != null)
-			  | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
-			  | select(.id | endswith("@" + $snap))
-			  | .id
-			' < "$entryfile" | head -n1
-		)"
-	fi
-
-	# Otherwise: take the first UKI for this snapshot
-	if [ -z "$candidate" ]; then
-		candidate="$(
-			jq -r --arg snap "$snapshot" '
-			  .[]
-			  | select(.linux? != null)
-			  | select(.linux | test("^/EFI/Linux/openSUSE-.*-[0-9a-f]{40}\\.efi$"))
-			  | select(.id | endswith("@" + $snap))
-			  | .id
-			' < "$entryfile" | head -n1
-		)"
-	fi
-
-	# Fallback: any entry for this snapshot
-	if [ -z "$candidate" ]; then
-		candidate="$(
-			jq -r --arg snap "$snapshot" '
-			  .[] | select(.id | endswith("@" + $snap)) | .id
-			' < "$entryfile" | head -n1
-		)"
-	fi
-
-	[ -n "$candidate" ] && echo "$candidate"
+	# If we only have "linux-<sha>" without its parent folder, there’s no KV to extract.
+	printf '%s' ""
+	return 1
 }
 
 grubenv_set()
@@ -2491,20 +2360,138 @@ get_timeout()
 	fi
 }
 
-entry_id_exists() {
-	local id="${1:?}"
-	local saved="$entryfile"
+build_uki_workdir()
+{
+	local kv="${1:?}"
+	local sum="${2:?}"
+	local linuxdir="$boot_root/EFI/Linux"
+	local dir="${ukidir}/${kv}-${sum}"
+	mkdir -p "$linuxdir"
+	mkdir -p "$dir"
+
+	# Make sure we can write (and not immutable, just in case)
+	if [ ! -w "$dir" ]; then
+		chmod u+rwx "$dir" || true
+	fi
+
+	echo "$dir"
+}
+
+uki_sum_from_path()
+{
+	local p="${1:?}"; local base kv sum
+	base="${p##*/openSUSE-}"             # <kv>-<sum>.efi
+	[[ "$base" =~ ^(.+)-([0-9a-f]{40})\.efi$ ]] || return 1
+	kv="${BASH_REMATCH[1]}"; sum="${BASH_REMATCH[2]}"
+	echo "$kv $sum"
+}
+
+kernel_sum_for_snapshot()
+{
+	local snapshot="${1:?}" kv="${2:?}"
+	local path="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	local src="${path#"${subvol_prefix}"}/lib/modules/${kv}/${image}"
+	calc_chksum "$src"
+	echo "$chksum"
+}
+
+ukify_collect_args()
+{
+	local dir="${1:?}"
+	shopt -s nullglob
+	local f
+	for f in "${dir}"/initrd-*; do [ -f "$f" ] && echo "--initrd=$f"; done
+	for f in "${dir}"/profile-*.efi; do [ -f "$f" ] && echo "--join-profile=$f"; done
+	shopt -u nullglob
+}
+
+build_uki_profile()
+{
+	local snap="${1:?}" kv="${2:?}" sum="${3:?}" cmd="${4:?}"
+	local title="${snapshot}@${kv}"
+	local subvol=""
+	[ -z "$have_snapshots" ] || subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	if subvol_is_ro "$subvol" && ! is_transactional; then
+		title="Snapper: $title"
+	fi
+	local dir; dir="$(build_uki_workdir "$kv" "$sum")"
+	mkdir -p "$dir"
+	ukify build \
+		--profile="TITLE=${title}${nl}ID=${snap}" \
+		--cmdline="$cmd" \
+		--output="${dir}/profile-${snap}.efi"
+}
+
+build_uki_image()
+{
+	local kv="${1:?}" sum="${2:?}" out="${3:?}"
+	local dir; dir="$(build_uki_workdir "$kv" "$sum")"
+	local linux_src="${dir}/${image}"
+	[ -f "$linux_src" ] || err "Missing ${linux_src} (kernel copy not staged)."
+
+	mapfile -t extra < <(ukify_collect_args "$dir")
+	ukify build --linux="$linux_src" --output="$out" "${extra[@]}"
+}
+
+ensure_image_in_workdir()
+{
+	local snap="${1:?}" kv="${2:?}" sum="${3:?}"
+	local work; work="$(build_uki_workdir "$kv" "$sum")"; mkdir -p "$work"
+	local src="${subvol_prefix}/.snapshots/${snap}/snapshot"
+	src="${src#"${subvol_prefix}"}/lib/modules/${kv}/${image}"
+	[ -f "${work}/${image}" ] || cp "$src" "${work}/${image}"
+}
+
+jq_effective_cmdline='(.options? // .cmdline? // "")'
+
+find_uki_entry()
+{
+	local snap="${1:?}" kv="${2:?}"
+	update_entries_for_snapshot "$snap"
+	jq -r --arg kv "$kv" '
+	  .[] | select(.linux? != null)
+		  | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+		  | [ .id, .linux, '"${jq_effective_cmdline}"', (.title // .showTitle // "") ] | @tsv
+	' < "$entryfile" | head -n1
+}
+
+# The best (type2-then-type1) bootctl id to set for a given snapshot.
+pick_entry_id_for_snapshot()
+{
+	local snap="${1:?}"
+
+	# Read current default first to potentialy prefer its KV
+	local default_id default_kv
+	default_id="$(get_default_entry || true)"
+	default_kv="$(kv_from_any "$default_id")"
+
+	update_entries_for_snapshot "$snap"
+
+	# Try: UKI for same KV, else any UKI, else any entry ending with @<snap>
+	local id
+	id="$(jq -r --arg kv "$default_kv" --arg s "$snap" '
+		   .[]
+		   | select(.linux? != null)
+		   | select(.linux | test("^/EFI/Linux/openSUSE-" + $kv + "-[0-9a-f]{40}\\.efi$"))
+		   | select(.id | endswith("@" + $s))
+		   | .id' < "$entryfile" | head -n1)"
+	[ -n "$id" ] || id="$(jq -r --arg s "$snap" '
+		   .[] | select(.linux? != null)
+		   | select(.linux | test("^/EFI/Linux/openSUSE-.*-[0-9a-f]{40}\\.efi$"))
+		   | select(.id | endswith("@" + $s)) | .id' < "$entryfile" | head -n1)"
+	[ -n "$id" ] || id="$(jq -r --arg s "$snap" '.[] | select(.id|endswith("@" + $s)) | .id' < "$entryfile" | head -n1)"
+	[ -n "$id" ] && echo "$id"
+}
+
+entry_id_exists()
+{
+	local id="${1:?}"; local saved="$entryfile"
 	update_entries_for_this_system
-	local ok
-	ok=$(jq -r '.[].id' < "$entryfile" | grep -Fx -- "$id" || true)
-	[ -n "$ok" ]
+	jq -r '.[].id' < "$entryfile" | grep -Fxq -- "$id"
 	entryfile="$saved"
 }
 
-is_type2_id() {
-	# UKI ids look like: openSUSE-<kv>-<sha40>.efi@<profile-id>
-	[[ "$1" =~ \.efi@[0-9]+$ ]]
-}
+is_type2_id() { [[ "$1" =~ \.efi@[0-9]+$ ]]; }
 
 set_default_snapshot()
 {

--- a/sdbootutil
+++ b/sdbootutil
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Copyright 2023 SUSE LLC
 set -e
 shopt -s nullglob
+source "/etc/sdbootutil"
 
 DEBUG_LOG="/var/log/sdbootutil.log"
 
@@ -16,6 +17,7 @@ fi
 verbose=
 nl=$'\n'
 shimdir="/usr/share/efi/$(uname -m)"
+ukidir="/var/lib/sdbootutil/uki"
 arg_esp_path="$SYSTEMD_ESP_PATH"
 arg_entry_token=
 arg_arch=
@@ -23,6 +25,7 @@ arg_all_entries=
 arg_entry_keys=()
 arg_no_variables=
 arg_no_reuse_initrd=
+arg_no_reuse_profile=
 arg_no_random_seed=
 arg_portable=
 arg_secure_boot=
@@ -109,6 +112,7 @@ helpandquit()
 		  --entry-keys		Comma separated list of keys
 		  --no-variables	Do not update UEFI variables
 		  --no-reuse-initrd	Always regenerate initrd
+		  --no-reuse-profile	Always regenerate UKI profile
 		  --sync		Synchronize (update, downgrade) the bootloader
 		  --portable		Handle bootloader on portable devices
 		                        (also --removable possible)
@@ -597,25 +601,6 @@ settle_entry_token()
 	return 0
 }
 
-remove_kernel()
-{
-	local snapshot="$1"
-	local kernel_version="$2"
-	[ -n "$kernel_version" ] || err "Missing kernel version"
-
-	info "Removing kernel $kernel_version"
-	dbg_var "snapshot"
-
-	settle_entry_token "${snapshot}"
-	local id
-	id="$(entry_conf_file "$kernel_version" "$snapshot")"
-	info "Removing boot entry $id"
-	bootctl unlink "$id"
-
-	# This action will require to update the PCR predictions
-	update_predictions=1
-}
-
 install_with_rollback()
 {
 	local src="${1:?}"
@@ -632,6 +617,89 @@ install_with_rollback()
 	install -p -m 0644 "$src" "$dst" || return "$?"
 	chown root:root "$dst" 2>/dev/null || :
 	info "Installed $dst"
+}
+
+remove_uki()
+{
+	local snapshot="$1"
+	local kernel_version="$2"
+	
+	# Remove this snapshot's profile
+	local dir="$ukidir/${kernel_version}"
+	local prof="$dir/profile-${snapshot}.efi"
+	if [ -f "$prof" ]; then
+		info "Deleting profile for snapshot $snapshot"
+		rm -f "$prof"
+	else
+		warn "Profile for snapshot $snapshot not found; skipping delete"
+	fi
+
+	# Rebuild or purge UKI
+	shopt -s nullglob
+	# gather remaining profiles
+	local remaining_profiles=( "$dir"/profile-*.efi )
+	shopt -u nullglob
+
+	if [ "${#remaining_profiles[@]}" -gt 0 ]; then
+		# still have other profiles --> rebuild UKI
+		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
+		local tmp_uki="$tmpdir/uki-${kernel_version}.efi"
+		local ukify_args=(
+			--linux="${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image"
+			--output="$tmp_uki"
+		)
+		# add all initrds
+		for initrd in "$dir"/initrd-*; do
+			[ -f "$initrd" ] || continue
+			ukify_args+=(--initrd="$initrd")
+		done
+		# add all remaining profiles
+		for p in "${remaining_profiles[@]}"; do
+			ukify_args+=(--join-profile="$p")
+		done
+
+		ukify build "${ukify_args[@]}"
+		make_free_space_for_uki "$tmp_uki" || err "No free space in $boot_root for new UKI"
+		install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-$kernel_version-$chksum.efi"  || failed="UKI"
+		rm -f "$tmp_uki"
+
+		[ -z "$failed" ] || err "Failed to install $failed"
+		reset_rollback
+
+	else
+		# no profiles left --> remove entire kernel dir + UKI file
+		info "No snapshots left for $kernel_version; removing all artifacts"
+		rm -rf "$dir"
+		# remove the on-disk UKI(s)
+		rm -f "$linuxdir/openSUSE-${kernel_version}-"*.efi
+	fi
+
+	# This action will require to update the PCR predictions
+	update_predictions=1
+}
+
+remove_kernel()
+{
+	local snapshot="$1"
+	local kernel_version="$2"
+	[ -n "$kernel_version" ] || err "Missing kernel version"
+
+	info "Removing kernel $kernel_version"
+	dbg_var "snapshot"
+
+	if [ -n "$use_uki" ]; then
+		remove_uki "$snapshot" "$kernel_version"
+		return
+	fi
+
+	settle_entry_token "${snapshot}"
+	local id
+	id="$(entry_conf_file "$kernel_version" "$snapshot")"
+	info "Removing boot entry $id"
+	bootctl unlink "$id"
+
+	# This action will require to update the PCR predictions
+	update_predictions=1
 }
 
 update_snapper()
@@ -712,7 +780,10 @@ reuse_initrd()
 	local conf
 
 	[ -z "$arg_no_reuse_initrd" ] || return 1
-	settle_entry_token "${snapshot}"
+	settle_entry_token "${snapshot}"+
+
+	# Check if in our UKI build dir is our initrd
+	[ -z "$use_uki" ] || [ -f "$ukidir/${kernel_version}/initrd-0" ]
 
 	conf="$(find_conf_file "$kernel_version" "${snapshot}")"
 	local find_conf_status=$?
@@ -740,6 +811,17 @@ reuse_initrd()
 	fi
 
 	return 1
+}
+
+reuse_profile()
+{
+	local snapshot="$1"
+	local kernel_version="${2:?}"
+
+	[ -z "$arg_no_reuse_profile" ] || return 1
+
+	# Check if a profile already exists for the snapshot
+	[ -f "${ukidir}/${kernel_version}/profile-${snapshot}.efi" ]
 }
 
 mount_chroot()
@@ -975,6 +1057,19 @@ make_free_space_for_kernel()
 	make_free_space "$snapshot" "$total_size"
 }
 
+make_free_space_for_uki()
+{
+	local uki="$1"
+
+	# Calculate the free space and the required size.  All sizes
+	# are in Kb to avoid big numbers
+	local free_space total_size
+	total_size=$(($(pending_kernel_size "$uki")))
+
+	# TODO: Needs adoption to work with UKIs
+	make_free_space "$snapshot" "$total_size"
+}
+
 create_boot_options() {
 	local subvol="$1"
 	local boot_options=
@@ -1005,10 +1100,13 @@ install_kernel()
 	calc_chksum "$src"
 	settle_entry_token "${snapshot}"
 	local dst="/$entry_token/$kernel_version/linux-$chksum"
+	local linuxdir="$boot_root/EFI/Linux"
 
 	local initrd="${src%/*}/initrd"
 
 	mkdir -p "$boot_root${dst%/*}"
+	[ -z "$use_uki" ] || mkdir -p "$linuxdir"
+	[ -z "$use_uki" ] || mkdir -p "$ukidir/${kernel_version}"
 
 	if [ -e "$initrd" ]; then
 		ln -s "$initrd" "$tmpdir/initrd-0"
@@ -1048,19 +1146,8 @@ install_kernel()
 		fi
 	fi
 
-	make_free_space_for_kernel "$snapshot" || err "No free space in $boot_root for new kernel"
-
 	local boot_options
 	boot_options="$(create_boot_options "$subvol")"
-
-	if [ "${#dstinitrd[@]}" -eq 0 ] && [ -e "$tmpdir/initrd-0" ]; then
-		i=0
-		while [ -e "$tmpdir/initrd-$i" ]; do
-			calc_chksum "$tmpdir/initrd-$i"
-			dstinitrd+=("${dst%/*}/initrd-$chksum")
-			((++i))
-		done
-	fi
 
 	title="${os_release_PRETTY_NAME:-Linux $kernel_version}"
 	# shellcheck disable=SC2154
@@ -1071,6 +1158,65 @@ install_kernel()
 		set_snapper_title_and_sortkey "$snapshot"
 	elif is_grub2_bls; then
 		add_kernel_version_to_title
+	fi
+
+	if [ -n "$use_uki" ]; then
+		if [ -e "$tmpdir/initrd-0" ]; then
+			i=0
+			while [ -e "$tmpdir/initrd-$i" ]; do
+				install_with_rollback "$tmpdir/initrd-$i" "$ukidir/${kernel_version}/initrd-$i" || { failed=initrd; break; }
+				rm -f "$tmpdir/initrd-$i"
+				((++i))
+			done
+		fi
+		if ! reuse_profile "$snapshot" "$kernel_version"; then
+			info "Building UKI profile for snapshot $snapshot"
+			ukify build \
+			   --profile="TITLE=${title}${sort_key:+${nl}ID=$sort_key}" \
+        	   --cmdline="$boot_options" \
+        	   --output="$ukidir/${kernel_version}/profile-${snapshot}.efi"
+		else
+			info "Found existing UKI profile for snapshot $snapshot"
+		fi
+		info "Building UKI for kernel $kernel_version"
+		local ukify_args=(
+			--linux="${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image"
+			--output="$tmpdir/uki-${kernel_version}.efi"
+		)
+		shopt -s nullglob
+		for initrd in "$ukidir"/"${kernel_version}"/initrd-*; do
+        	[ -f "$initrd" ] || continue
+        	ukify_args+=(--initrd="$initrd")
+    	done
+		for prof in "$ukidir"/"${kernel_version}"/profile-*.efi; do
+        	[ -f "$prof" ] || continue
+        	ukify_args+=(--join-profile="$prof")
+    	done
+		shopt -u nullglob
+		ukify build "${ukify_args[@]}"
+
+		make_free_space_for_uki "$tmpdir/uki-${kernel_version}.efi" || err "No free space in $boot_root for new UKI"
+
+		install_with_rollback "$tmpdir/uki-${kernel_version}.efi" "$linuxdir/openSUSE-$kernel_version-$chksum.efi" || failed="UKI"
+		rm -f "$tmpdir/uki-${kernel_version}.efi"
+
+		[ -z "$failed" ] || err "Failed to install $failed"
+		reset_rollback
+
+		# This action will require to update the PCR predictions
+		update_predictions=1
+		return
+	fi
+
+	make_free_space_for_kernel "$snapshot" || err "No free space in $boot_root for new kernel"
+
+	if [ "${#dstinitrd[@]}" -eq 0 ] && [ -e "$tmpdir/initrd-0" ]; then
+		i=0
+		while [ -e "$tmpdir/initrd-$i" ]; do
+			calc_chksum "$tmpdir/initrd-$i"
+			dstinitrd+=("${dst%/*}/initrd-$chksum")
+			((++i))
+		done
 	fi
 
 	local entry_machine_id=
@@ -3637,6 +3783,7 @@ define_options() {
 		[entry-keys]="_find_kernels"
 		[no-variables]=""
 		[no-reuse-initrd]=""
+		[no-reuse-profile]=""
 		[no-random-seed]=""
 		[all]=""
 		[sync]=""
@@ -3691,6 +3838,7 @@ while true ; do
 		--entry-keys) IFS=',' read -r -a arg_entry_keys <<<"$2"; shift 2 ;;
 		--no-variables) arg_no_variables=1; shift ;;
 		--no-reuse-initrd) arg_no_reuse_initrd=1; shift ;;
+		--no-reuse-profile) arg_no_reuse_profile=1; shift ;;
 		--no-random-seed) arg_no_random_seed=1; shift ;;
 		--all) arg_all_entries=1; shift ;;
 		--sync) arg_sync=1; shift ;;

--- a/sdbootutil
+++ b/sdbootutil
@@ -624,8 +624,13 @@ remove_uki()
 	local snapshot="$1"
 	local kernel_version="$2"
 	
+	subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
+	calc_chksum "$src"
+	ker_chksum="$chksum"
+
 	# Remove this snapshot's profile
-	local dir="$ukidir/${kernel_version}"
+	local dir="${ukidir}/${kernel_version}-${ker_chksum}"
 	local prof="$dir/profile-${snapshot}.efi"
 	if [ -f "$prof" ]; then
 		info "Deleting profile for snapshot $snapshot"
@@ -779,11 +784,18 @@ reuse_initrd()
 	local kernel_version="${3:?}"
 	local conf
 
+	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
+	calc_chksum "$src"
+	ker_chksum="$chksum"
+
 	[ -z "$arg_no_reuse_initrd" ] || return 1
 	settle_entry_token "${snapshot}"+
 
 	# Check if in our UKI build dir is our initrd
-	[ -z "$use_uki" ] || [ -f "$ukidir/${kernel_version}/initrd-0" ]
+	if [ -n "$use_uki" ]; then
+		[ -f "${ukidir}/${kernel_version}-${ker_chksum}/initrd-0" ]
+		return $?
+	fi
 
 	conf="$(find_conf_file "$kernel_version" "${snapshot}")"
 	local find_conf_status=$?
@@ -817,11 +829,15 @@ reuse_profile()
 {
 	local snapshot="$1"
 	local kernel_version="${2:?}"
+	subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
+	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
+	calc_chksum "$src"
+	ker_chksum="$chksum"
 
 	[ -z "$arg_no_reuse_profile" ] || return 1
 
 	# Check if a profile already exists for the snapshot
-	[ -f "${ukidir}/${kernel_version}/profile-${snapshot}.efi" ]
+	[ -f "${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi" ]
 }
 
 mount_chroot()
@@ -1096,17 +1112,18 @@ install_kernel()
 
 	info "Installing kernel $kernel_version"
 	dbg_var "snapshot"
-
+	
 	calc_chksum "$src"
+	ker_chksum="$chksum"
 	settle_entry_token "${snapshot}"
-	local dst="/$entry_token/$kernel_version/linux-$chksum"
+	local dst="/$entry_token/$kernel_version/linux-$ker_chksum"
 	local linuxdir="$boot_root/EFI/Linux"
 
 	local initrd="${src%/*}/initrd"
 
 	mkdir -p "$boot_root${dst%/*}"
 	[ -z "$use_uki" ] || mkdir -p "$linuxdir"
-	[ -z "$use_uki" ] || mkdir -p "$ukidir/${kernel_version}"
+	[ -z "$use_uki" ] || mkdir -p "${ukidir}/${kernel_version}-${ker_chksum}"
 
 	if [ -e "$initrd" ]; then
 		ln -s "$initrd" "$tmpdir/initrd-0"
@@ -1164,34 +1181,39 @@ install_kernel()
 		if [ -e "$tmpdir/initrd-0" ]; then
 			i=0
 			while [ -e "$tmpdir/initrd-$i" ]; do
-				install_with_rollback "$tmpdir/initrd-$i" "$ukidir/${kernel_version}/initrd-$i" || { failed=initrd; break; }
+				install_with_rollback "$tmpdir/initrd-$i" "${ukidir}/${kernel_version}-${ker_chksum}/initrd-$i" || { failed=initrd; break; }
 				rm -f "$tmpdir/initrd-$i"
 				((++i))
 			done
 		fi
-		if ! reuse_profile "$snapshot" "$kernel_version"; then
-			info "Building UKI profile for snapshot $snapshot"
-			ukify build \
-			   --profile="TITLE=${title}${sort_key:+${nl}ID=$sort_key}" \
-        	   --cmdline="$boot_options" \
-        	   --output="$ukidir/${kernel_version}/profile-${snapshot}.efi"
-		else
-			info "Found existing UKI profile for snapshot $snapshot"
-		fi
-		info "Building UKI for kernel $kernel_version"
 		local ukify_args=(
 			--linux="${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image"
 			--output="$tmpdir/uki-${kernel_version}.efi"
 		)
+		if ! reuse_profile "$snapshot" "$kernel_version"; then
+			info "Building UKI profile for snapshot $snapshot"
+			if [ "$snapshot" != "$root_snapshot" ]; then
+				ukify build \
+			   	  --profile="TITLE=${title}${snapshot:+${nl}ID=$snapshot}" \
+        		  --cmdline="$boot_options" \
+        		  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
+			fi
+		else
+			info "Found existing UKI profile for snapshot $snapshot"
+		fi
+		info "Building UKI for kernel $kernel_version"
 		shopt -s nullglob
-		for initrd in "$ukidir"/"${kernel_version}"/initrd-*; do
+		for initrd in "${ukidir}/${kernel_version}-${ker_chksum}"/initrd-*; do
         	[ -f "$initrd" ] || continue
         	ukify_args+=(--initrd="$initrd")
     	done
-		for prof in "$ukidir"/"${kernel_version}"/profile-*.efi; do
+		for prof in "${ukidir}/${kernel_version}-${ker_chksum}"/profile-*.efi; do
         	[ -f "$prof" ] || continue
         	ukify_args+=(--join-profile="$prof")
     	done
+		root_subvol="${subvol_prefix}/.snapshots/${root_snapshot}/snapshot"
+		root_boot_options="$(create_boot_options "$root_subvol")"
+		ukify_args+=(--cmdline="$root_boot_options")
 		shopt -u nullglob
 		ukify build "${ukify_args[@]}"
 

--- a/sdbootutil
+++ b/sdbootutil
@@ -1685,57 +1685,93 @@ declare -A installed_kernels
 # Map of ESP path to id of kernels that are not in the subvol
 declare -A stale_kernels
 is_bootable=
-update_kernels()
-{
+update_kernels() {
 	local snapshot="$1"
-	local path id
+	local path id sum
 	installed_kernels=()
 	stale_kernels=()
 	is_bootable=
 	find_kernels "$snapshot"
-	settle_entry_token "${snapshot}"
+	settle_entry_token "${snapshot}"	
+	# Seed expected ESP paths for each found kernel version
 	for kv in "${!found_kernels[@]}"; do
-		installed_kernels["/$entry_token/$kv/linux-${found_kernels[$kv]}"]=''
-	done
-	update_entries_for_snapshot "$snapshot"
-
-	# XXX: maybe we should parse the actual path in the entry
+		sum="${found_kernels[$kv]}"
+		# classic BLS kernel image path
+		installed_kernels["/$entry_token/$kv/linux-$sum"]=''
+		# UKI path used by sdbootutil (and bootctl type2)
+		installed_kernels["/EFI/Linux/openSUSE-$kv-$sum.efi"]=''
+	done	
+	update_entries_for_snapshot "$snapshot"	
+	# Fill matches from bootctl JSON and mark truly stale ones
 	while read -r path id; do
-		if [ "${installed_kernels[$path]+none}" = 'none' ]; then
+		if [[ -v 'installed_kernels[$path]' ]]; then
 			installed_kernels["$path"]="$id"
 			is_bootable=1
-		else
-			# kernel in ESP that is not installed
+		# mark "stale" only if it looks like one of our kernel layouts
+		elif [[ "$path" == /$entry_token/*/linux-* || "$path" == /EFI/Linux/openSUSE-*.efi ]]; then
 			stale_kernels["$path"]="$id"
 		fi
-	done < <(jq -r '.[]|select(has("linux"))|[.linux,.id]|join(" ")'< "$entryfile")
+	done < <(jq -r '.[]|select(has("linux"))|[.linux,.id]|join(" ")' < "$entryfile")
 }
 
-list_kernels()
-{
+kv_from_path() {
+	local p="$1" base
+	case "$p" in
+		# classic BLS: /$entry_token/<kv>/linux-<sha>
+		"/$entry_token/"*"/linux-"*)
+		  base="${p#"/$entry_token/"}"
+		  printf '%s\n' "${base%%/*}"
+		  ;;
+		# UKI: /EFI/Linux/openSUSE-<kv>-<sha>.efi
+		/EFI/Linux/openSUSE-*.efi)
+		  base="${p##*/openSUSE-}"          # <kv>-<sha>.efi
+		  if [[ "$base" =~ ^(.+)-([0-9a-f]{40})\.efi$ ]]; then
+		  	printf '%s\n' "${BASH_REMATCH[1]}"
+		  fi
+		  ;;
+	esac
+}
+
+list_kernels() {
 	local snapshot=""
 	[ -z "$have_snapshots" ] || snapshot="${1:?}"
 
 	info "Listing kernels"
 
 	update_kernels "$snapshot"
-	local kernelfiles=("${!installed_kernels[@]}")
-	for k in "${kernelfiles[@]}"; do
-		local id="${installed_kernels[$k]}"
-		local kv="${k%/*}"
-		kv="${kv##*/}"
-		if [ -z "$id" ]; then
-			echo -e "${color_yellow}missing /lib/modules/$kv/$image${color_end}"
-		else
-			echo -e "${color_green}ok /lib/modules/$kv/$image -> $id${color_end}"
+
+	# Aggregate by kv: ok if any layout matched
+	declare -A kv_any_matched kv_any_expected kv_example_path kv_example_id
+	local k id kv
+
+	for k in "${!installed_kernels[@]}"; do
+		kv="$(kv_from_path "$k")"
+		[ -n "$kv" ] || continue
+		kv_any_expected["$kv"]=1
+		id="${installed_kernels[$k]}"
+		if [ -n "$id" ]; then
+			kv_any_matched["$kv"]=1
+			kv_example_path["$kv"]="$k"
+			kv_example_id["$kv"]="$id"
 		fi
 	done
-	kernelfiles=("${!stale_kernels[@]}")
-	for k in "${kernelfiles[@]}"; do
-		local id="${stale_kernels[$k]}"
-		printf "${color_red}stale %s${color_end}\n" "$id"
+
+	# Print once per kernel version
+	for kv in "${!kv_any_expected[@]}"; do
+		if [ -n "${kv_any_matched[$kv]+x}" ]; then
+			# show a representative mapping
+			echo -e "${color_green}ok /lib/modules/$kv/$image -> ${kv_example_id[$kv]}${color_end}"
+		else
+			echo -e "${color_yellow}missing /lib/modules/$kv/$image${color_end}"
+		fi
+	done
+
+	# Stale: entries that look like our kernel layouts but don’t belong to this snapshot
+	for k in "${!stale_kernels[@]}"; do
+		printf "${color_red}stale %s${color_end}\n" "${stale_kernels[$k]}"
 	done
 }
+
 
 list_devices()
 {

--- a/sdbootutil
+++ b/sdbootutil
@@ -1529,7 +1529,7 @@ list_entries()
 		fi
 
 		local errors=()
-		if [ -n "$verbose" ] && [ -n "$conf" ] && [ -e "$conf" ]; then
+		if [ -n "$verbose" ] && [ "$type" = "type1" ] && [ -n "$conf" ] && [ -e "$conf" ]; then
 			local k
 			local v
 			while read -r k v; do

--- a/sdbootutil
+++ b/sdbootutil
@@ -521,21 +521,21 @@ update_entries_for_this_system()
 
 declare -A uki_uname_cache
 uki_uname() {
-    local path="${1:?}"
-    if [[ -n "${uki_uname_cache[$path]+x}" ]]; then
-        printf '%s' "${uki_uname_cache[$path]}"; return
-    fi
-    local kv=""
-    # Try JSON first (works with both full and --section outputs)
-    kv="$(ukify inspect --section=.uname --json "$path" 2>/dev/null \
-          | jq -r 'first( (.. | objects | select(.name?==".uname") | .text?) ) // ""')"
-    if [[ -z "$kv" ]]; then
-        # Plain-text fallback: read the line after "text:" within .uname section
-        kv="$(ukify inspect "$path" 2>/dev/null \
-              | awk '$1==".uname:"{f=1;next} f&&$1=="text:"{getline; sub(/^[[:space:]]+/,""); print; exit}')"
-    fi
-    uki_uname_cache[$path]="$kv"
-    printf '%s' "$kv"
+	local path="${1:?}"
+	if [[ -n "${uki_uname_cache[$path]+x}" ]]; then
+		printf '%s' "${uki_uname_cache[$path]}"; return
+	fi
+	local kv=""
+	# Try JSON first (works with both full and --section outputs)
+	kv="$(ukify inspect --section=.uname --json "$path" 2>/dev/null \
+		  | jq -r 'first( (.. | objects | select(.name?==".uname") | .text?) ) // ""')"
+	if [[ -z "$kv" ]]; then
+		# Plain-text fallback: read the line after "text:" within .uname section
+		kv="$(ukify inspect "$path" 2>/dev/null \
+			  | awk '$1==".uname:"{f=1;next} f&&$1=="text:"{getline; sub(/^[[:space:]]+/,""); print; exit}')"
+	fi
+	uki_uname_cache[$path]="$kv"
+	printf '%s' "$kv"
 }
 
 entry_conf_file()
@@ -1114,31 +1114,31 @@ select_uki_entries_for_free_space()
 	bootctl list --json=short | \
 	jq --arg re "$protected_re" --arg run "${running_linux:-}" '
 	  [ .[]
-	    | select(has("linux"))
-	    | select(.linux | test("^/EFI/Linux/.*\\.efi$"))
+		| select(has("linux"))
+		| select(.linux | test("^/EFI/Linux/.*\\.efi$"))
 	  ]
 	  | group_by(.linux)
 	  | map({
-	      linux: .[0].linux,
-	      id: .[0].id,
-	      isDefault: any(.[]; .isDefault == true),
-	      isSelected: any(.[]; .isSelected == true),
-	      snaps: (
-	        [ .[]
-	          | ((.options // .cmdline // ""))
-	          | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>[0-9]+)/snapshot")?
-	          | .sid? | tonumber?
-	        ] | map(select(. != null))
-	      ),
-	      kernel: ((.[0].linux | scan("(\\d+)\\.(\\d+)\\.(\\d+)-(\\d+)")) | map(tonumber))
-	    })
+		  linux: .[0].linux,
+		  id: .[0].id,
+		  isDefault: any(.[]; .isDefault == true),
+		  isSelected: any(.[]; .isSelected == true),
+		  snaps: (
+			[ .[]
+			  | ((.options // .cmdline // ""))
+			  | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>[0-9]+)/snapshot")?
+			  | .sid? | tonumber?
+			] | map(select(. != null))
+		  ),
+		  kernel: ((.[0].linux | scan("(\\d+)\\.(\\d+)\\.(\\d+)-(\\d+)")) | map(tonumber))
+		})
 	  | map(. + {
-	      protected: (
-	        .isDefault or .isSelected or (.linux == $run) or
-	        any(.snaps[]?; (tostring | test("^" + $re + "$")))
-	      ),
-	      prio: ((.snaps | select(length>0) | min) // 999999)
-	    })
+		  protected: (
+			.isDefault or .isSelected or (.linux == $run) or
+			any(.snaps[]?; (tostring | test("^" + $re + "$")))
+		  ),
+		  prio: ((.snaps | select(length>0) | min) // 999999)
+		})
 	  | map(select(.protected | not))
 	  | map({id, linux, prio, kernel})
 	' > "$entryfile"
@@ -1146,7 +1146,6 @@ select_uki_entries_for_free_space()
 	dbg "Selected UKI groups for free space"
 	dbg_cat "$entryfile"
 }
-
 
 make_free_space_for_uki()
 {
@@ -1299,21 +1298,21 @@ install_kernel()
 			info "Building UKI profile for snapshot $snapshot"
 			ukify build \
 			  --profile="TITLE=${title}${snapshot:+${nl}ID=$snapshot}" \
-        	  --cmdline="$boot_options" \
-        	  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
+			  --cmdline="$boot_options" \
+			  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
 		else
 			info "Found existing UKI profile for snapshot $snapshot"
 		fi
 		info "Building UKI for kernel $kernel_version"
 		shopt -s nullglob
 		for initrd in "${ukidir}/${kernel_version}-${ker_chksum}"/initrd-*; do
-        	[ -f "$initrd" ] || continue
-        	ukify_args+=(--initrd="$initrd")
-    	done
+			[ -f "$initrd" ] || continue
+			ukify_args+=(--initrd="$initrd")
+		done
 		for prof in "${ukidir}/${kernel_version}-${ker_chksum}"/profile-*.efi; do
-        	[ -f "$prof" ] || continue
-        	ukify_args+=(--join-profile="$prof")
-    	done
+			[ -f "$prof" ] || continue
+			ukify_args+=(--join-profile="$prof")
+		done
 		shopt -u nullglob
 		ukify build "${ukify_args[@]}"
 
@@ -1467,13 +1466,13 @@ cleanup_entries()
 	done < <(
 		jq -r '
 		  [ .[]
-		    | select(has("linux"))
-		    | select(.linux | test("^/EFI/Linux/.*\\.efi$"))
-		    | ( .options // .cmdline // "" ) as $cmd
-		    | select($cmd | test("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/\\d+/snapshot"))
-		    | [ .id
-		      , ($cmd | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>\\d+)/snapshot").sid)
-		      , .linux ] | @tsv ] | .[]' "$entryfile")
+			| select(has("linux"))
+			| select(.linux | test("^/EFI/Linux/.*\\.efi$"))
+			| ( .options // .cmdline // "" ) as $cmd
+			| select($cmd | test("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/\\d+/snapshot"))
+			| [ .id
+			  , ($cmd | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>\\d+)/snapshot").sid)
+			  , .linux ] | @tsv ] | .[]' "$entryfile")
 
 	# classic BLS type#1 entries (loader/entries/*.conf) — filter strictly to type1
 	local id snapshot kernel_version subvol src
@@ -1484,7 +1483,7 @@ cleanup_entries()
 			info "Cleaning boot entry $id"
 			# Try both with and without .conf to cover differing bootctl id formats
 			rm -f "${boot_root}/loader/entries/$id" \
-			      "${boot_root}/loader/entries/$id.conf"
+				  "${boot_root}/loader/entries/$id.conf"
 		fi
 	done < <(
 		jq -r '

--- a/sdbootutil
+++ b/sdbootutil
@@ -663,7 +663,7 @@ remove_uki()
 		done
 
 		ukify build "${ukify_args[@]}"
-		make_free_space_for_uki "$tmp_uki" || err "No free space in $boot_root for new UKI"
+		make_free_space_for_uki "$snapshot" "$tmp_uki" || err "No free space in $boot_root for new UKI"
 		install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-$kernel_version-$chksum.efi"  || failed="UKI"
 		rm -f "$tmp_uki"
 
@@ -1072,17 +1072,90 @@ make_free_space_for_kernel()
 	make_free_space "$snapshot" "$total_size"
 }
 
+select_uki_entries_for_free_space()
+{
+	local snapshot="$1"
+	local protected_re
+	protected_re="$(regex_snapshot_ids_for_free_space "$snapshot")"
+
+	local running_linux
+	running_linux="$(grep -oE 'BOOT_IMAGE=[^ ]*EFI/Linux/[^ ]+' /proc/cmdline | sed 's/^BOOT_IMAGE=//')" || true
+
+	bootctl list --json=short | \
+	jq --arg re "$protected_re" --arg run "${running_linux:-}" '
+	  [ .[]
+	    | select(has("linux"))
+	    | select(.linux | test("^/EFI/Linux/.*\\.efi$"))
+	  ]
+	  | group_by(.linux)
+	  | map({
+	      linux: .[0].linux,
+	      id: .[0].id,
+	      isDefault: any(.[]; .isDefault == true),
+	      isSelected: any(.[]; .isSelected == true),
+	      snaps: (
+	        [ .[]
+	          | ((.options // .cmdline // ""))
+	          | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>[0-9]+)/snapshot")?
+	          | .sid? | tonumber?
+	        ] | map(select(. != null))
+	      ),
+	      kernel: ((.[0].linux | scan("(\\d+)\\.(\\d+)\\.(\\d+)-(\\d+)")) | map(tonumber))
+	    })
+	  | map(. + {
+	      protected: (
+	        .isDefault or .isSelected or (.linux == $run) or
+	        any(.snaps[]?; (tostring | test("^" + $re + "$")))
+	      ),
+	      prio: ((.snaps | select(length>0) | min) // 999999)
+	    })
+	  | map(select(.protected | not))
+	  | map({id, linux, prio, kernel})
+	' > "$entryfile"
+
+	dbg "Selected UKI groups for free space"
+	dbg_cat "$entryfile"
+}
+
+
 make_free_space_for_uki()
 {
-	local uki="$1"
+	local snapshot="$1"
+	local uki="$2"
 
 	# Calculate the free space and the required size.  All sizes
 	# are in Kb to avoid big numbers
 	local free_space total_size
 	total_size=$(($(pending_kernel_size "$uki")))
 
-	# TODO: Needs adoption to work with UKIs
-	make_free_space "$snapshot" "$total_size"
+	info "Required free space in ESP: $total_size KB"
+
+	free_space="$(boot_free_space)"
+	[ "$total_size" -gt "$free_space" ] || return 0
+
+	# Clean obvious cruft
+	dbg "Calling bootctl cleanup"
+	bootctl -q cleanup 2> /dev/null
+
+	# Build UKI removal candidates (grouped per /EFI/Linux/*.efi)
+	select_uki_entries_for_free_space "$snapshot"
+
+	# Remove low-priority UKIs until we have enough space
+	local id
+	while read -r id; do
+		free_space="$(boot_free_space)"
+		dbg "Free space in the ESP: $free_space KB"
+		if [ "$total_size" -gt "$free_space" ]; then
+			info "Removing UKI via boot entry $id"
+			bootctl unlink "$id"
+		else
+			return 0
+		fi
+	done < <(jq -r 'sort_by(.prio, .kernel) | .[] | .id' < "$entryfile")
+
+	free_space="$(boot_free_space)"
+	dbg "Free space in the ESP after deallocation: $free_space KB"
+	[ "$total_size" -lt "$free_space" ]
 }
 
 create_boot_options() {
@@ -1191,12 +1264,10 @@ install_kernel()
 		)
 		if ! reuse_profile "$snapshot" "$kernel_version"; then
 			info "Building UKI profile for snapshot $snapshot"
-			if [ "$snapshot" != "$root_snapshot" ]; then
-				ukify build \
-			   	  --profile="TITLE=${title}${snapshot:+${nl}ID=$snapshot}" \
-        		  --cmdline="$boot_options" \
-        		  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
-			fi
+			ukify build \
+			  --profile="TITLE=${title}${snapshot:+${nl}ID=$snapshot}" \
+        	  --cmdline="$boot_options" \
+        	  --output="${ukidir}/${kernel_version}-${ker_chksum}/profile-${snapshot}.efi"
 		else
 			info "Found existing UKI profile for snapshot $snapshot"
 		fi
@@ -1210,13 +1281,10 @@ install_kernel()
         	[ -f "$prof" ] || continue
         	ukify_args+=(--join-profile="$prof")
     	done
-		root_subvol="${subvol_prefix}/.snapshots/${root_snapshot}/snapshot"
-		root_boot_options="$(create_boot_options "$root_subvol")"
-		ukify_args+=(--cmdline="$root_boot_options")
 		shopt -u nullglob
 		ukify build "${ukify_args[@]}"
 
-		make_free_space_for_uki "$tmpdir/uki-${kernel_version}.efi" || err "No free space in $boot_root for new UKI"
+		make_free_space_for_uki "$snapshot" "$tmpdir/uki-${kernel_version}.efi" || err "No free space in $boot_root for new UKI"
 
 		install_with_rollback "$tmpdir/uki-${kernel_version}.efi" "$linuxdir/openSUSE-$kernel_version-$chksum.efi" || failed="UKI"
 		rm -f "$tmpdir/uki-${kernel_version}.efi"

--- a/sdbootutil
+++ b/sdbootutil
@@ -493,7 +493,11 @@ update_entries_for_subvol()
 	local ext="${2:-}"
 
 	[ -z "$ext" ] || ext="|$ext"
-	update_entries jq "[.[]|select(has(\"options\"))|select(.options|test(\"root=(?:UUID=$root_uuid|$root_device) .*rootflags=subvol=$subvol\")$ext)]"
+	# Look at .options (BLS #1) OR .cmdline (UKI auto-entry)
+	update_entries jq "[.[] \
+	  | select(has(\"options\") or has(\"cmdline\")) \
+	  | select((.options // .cmdline) \
+	  | test(\"root=(?:UUID=$root_uuid|$root_device) .*rootflags=subvol=$subvol\")$ext)]"
 }
 
 update_entries_for_snapshot()
@@ -510,7 +514,28 @@ update_entries_for_snapshot_invert()
 
 update_entries_for_this_system()
 {
-	update_entries jq "[.[]|select(has(\"options\"))|select(.options|test(\"root=(?:UUID=$root_uuid|$root_device)\"))]"
+	update_entries jq "[.[] \
+	  | select(has(\"options\") or has(\"cmdline\")) \
+	  | select((.options // .cmdline) | test(\"root=(?:UUID=$root_uuid|$root_device)\"))]"
+}
+
+declare -A uki_uname_cache
+uki_uname() {
+    local path="${1:?}"
+    if [[ -n "${uki_uname_cache[$path]+x}" ]]; then
+        printf '%s' "${uki_uname_cache[$path]}"; return
+    fi
+    local kv=""
+    # Try JSON first (works with both full and --section outputs)
+    kv="$(ukify inspect --section=.uname --json "$path" 2>/dev/null \
+          | jq -r 'first( (.. | objects | select(.name?==".uname") | .text?) ) // ""')"
+    if [[ -z "$kv" ]]; then
+        # Plain-text fallback: read the line after "text:" within .uname section
+        kv="$(ukify inspect "$path" 2>/dev/null \
+              | awk '$1==".uname:"{f=1;next} f&&$1=="text:"{getline; sub(/^[[:space:]]+/,""); print; exit}')"
+    fi
+    uki_uname_cache[$path]="$kv"
+    printf '%s' "$kv"
 }
 
 entry_conf_file()
@@ -622,15 +647,20 @@ remove_uki()
 {
 	local snapshot="$1"
 	local kernel_version="$2"
+	local ker_chksum="$3"
+	local linuxdir="$boot_root/EFI/Linux"
 	
 	subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
-	local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
-	calc_chksum "$src"
-	ker_chksum="$chksum"
+	if [ -z "$ker_chksum" ]; then
+		local src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
+		calc_chksum "$src"
+		ker_chksum="$chksum"
+	fi
 
 	# Remove this snapshot's profile
 	local dir="${ukidir}/${kernel_version}-${ker_chksum}"
 	local prof="$dir/profile-${snapshot}.efi"
+	dbg "Profile path: $prof"
 	if [ -f "$prof" ]; then
 		info "Deleting profile for snapshot $snapshot"
 		rm -f "$prof"
@@ -649,7 +679,7 @@ remove_uki()
 		info "Rebuilding UKI for kernel $kernel_version for remaining snapshots"
 		local tmp_uki="$tmpdir/uki-${kernel_version}.efi"
 		local ukify_args=(
-			--linux="${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image"
+			--linux="${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
 			--output="$tmp_uki"
 		)
 		# add all initrds
@@ -664,7 +694,7 @@ remove_uki()
 
 		ukify build "${ukify_args[@]}"
 		make_free_space_for_uki "$snapshot" "$tmp_uki" || err "No free space in $boot_root for new UKI"
-		install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-$kernel_version-$chksum.efi"  || failed="UKI"
+		install_with_rollback "$tmp_uki" "$linuxdir/openSUSE-$kernel_version-$ker_chksum.efi"  || failed="UKI"
 		rm -f "$tmp_uki"
 
 		[ -z "$failed" ] || err "Failed to install $failed"
@@ -1258,8 +1288,11 @@ install_kernel()
 				((++i))
 			done
 		fi
+
+		[ -f "${ukidir}/${kernel_version}-${ker_chksum}"/"$image" ] || cp "${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image" "${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
+
 		local ukify_args=(
-			--linux="${subvol#"$subvol_prefix"}"/lib/modules/"$kernel_version"/"$image"
+			--linux="${ukidir}/${kernel_version}-${ker_chksum}"/"$image"
 			--output="$tmpdir/uki-${kernel_version}.efi"
 		)
 		if ! reuse_profile "$snapshot" "$kernel_version"; then
@@ -1396,6 +1429,7 @@ cleanup_entries()
 {
 	info "Cleaning up boot entries"
 
+	# Ensure $entryfile is populated
 	if [ ! -s "$entryfile" ]; then
 		if [ -n "$1" ]; then
 			update_entries_for_snapshot "$1"
@@ -1404,17 +1438,62 @@ cleanup_entries()
 		fi
 	fi
 
+	# UKI entries - derive kernel version from UKI's .uname
+	declare -A _seen_uki_pair=()
+	while IFS=$'\t' read -r _id _snap _linux; do
+		key="${_snap}|${_linux}"
+		[ -z "${_seen_uki_pair[$key]+x}" ] || continue
+		_seen_uki_pair[$key]=1
+
+		if [ ! -f "$boot_root$_linux" ]; then
+			dbg "UKI $_linux not found on ESP; skipping"
+			continue
+		fi
+
+		kv="$(uki_uname "$boot_root$_linux")"
+		if [ -z "$kv" ]; then
+			dbg "No .uname in $_linux; skipping"
+			continue
+		fi
+
+		subvol="${subvol_prefix}/.snapshots/${_snap}/snapshot"
+		src="${subvol#"${subvol_prefix}"}/lib/modules/$kv/$image"
+		if [ ! -e "$src" ]; then
+			info "Cleaning UKI for snapshot $_snap, kernel $kv (entry $_id)"
+			ker_chksum="${_linux##*-}"
+			ker_chksum="${ker_chksum%.efi}"
+			remove_uki "$_snap" "$kv" "$ker_chksum"
+		fi
+	done < <(
+		jq -r '
+		  [ .[]
+		    | select(has("linux"))
+		    | select(.linux | test("^/EFI/Linux/.*\\.efi$"))
+		    | ( .options // .cmdline // "" ) as $cmd
+		    | select($cmd | test("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/\\d+/snapshot"))
+		    | [ .id
+		      , ($cmd | capture("rootflags=subvol=(?:@/)?(?:[^ ]*/)?\\.snapshots/(?<sid>\\d+)/snapshot").sid)
+		      , .linux ] | @tsv ] | .[]' "$entryfile")
+
+	# classic BLS type#1 entries (loader/entries/*.conf) — filter strictly to type1
 	local id snapshot kernel_version subvol src
-	while read -r id; do
-		read -r snapshot
-		read -r kernel_version
+	while IFS=$'\t' read -r id snapshot kernel_version; do
 		subvol="${subvol_prefix}/.snapshots/${snapshot}/snapshot"
 		src="${subvol#"${subvol_prefix}"}/lib/modules/$kernel_version/$image"
-		[ -e "$src" ] || {
+		if [ ! -e "$src" ]; then
 			info "Cleaning boot entry $id"
-			rm "${boot_root}/loader/entries/$id"
-		}
-	done < <(jq -r '.[] | .id, (.version | scan("(.*)@(.*)") | .[])' "$entryfile")
+			# Try both with and without .conf to cover differing bootctl id formats
+			rm -f "${boot_root}/loader/entries/$id" \
+			      "${boot_root}/loader/entries/$id.conf"
+		fi
+	done < <(
+		jq -r '
+		  .[]
+		  | select(.type=="type1")
+		  | (.version | capture("(?<snap>[^@]+)@(?<kv>.+)")) as $m
+		  | [ .id, $m.snap, $m.kv ] | @tsv
+		' "$entryfile"
+	)
 
 	dbg "Calling bootctl cleanup"
 	bootctl -q cleanup 2> /dev/null


### PR DESCRIPTION
This PR allows creating locally built UKIs uisng the Profiles feature to create a profile per snapshot and rebuilding the UKI. This means that per kernel version there only is one UKI, but it's still able to boot multiple snapshots. Since the UKIs are built locally, they also need to be signed locally using a MOK, but ukify _should_ already support this oob (untested) and ukify should also support PCR predictions for all profiles (untested)

This is only the first draft, the testing has been very limited, the code needs to be cleaned up and structured more usefully. The function to free space needs to be adapted.
This reads from /etc/sdbootutil whether UKis should be used or not, this should probably be done from /etc/sysconfig/bootloader

This is an alternative approach to #63 ; while #63 aims for centrally signed and distributed UKIs, this does not; but this one is able to work with the current snapshot layout of openSUSE, #63 is not really.

Should we go forward with this? With the profiles we don't have to have one UKI per snapshot, drastically reducing the downsides of UKIs. :)