### PR TITLE
Check for transactional systems by actually checking ro status

### DIFF
--- a/10-sdbootutil.snapper
+++ b/10-sdbootutil.snapper
@@ -6,7 +6,7 @@ set -e
 # check whether it's a transactional system
 is_transactional()
 {
-	findmnt --fstab / -O ro >/dev/null
+	[ ! -w /usr ] && [ -w /etc ]
 }
 
 # when creating a snapshot we fetch all bls configs from previous snapshot dir,

--- a/sdbootutil
+++ b/sdbootutil
@@ -333,7 +333,7 @@ reset_rollback()
 
 is_transactional()
 {
-	findmnt --fstab / -O ro >/dev/null
+	[ ! -w /usr ] && [ -w /etc ]
 }
 
 keyctl_add_with_timeout()


### PR DESCRIPTION
Checking the mount attribute only can mean an actual read-only root, transactional system incorrectly gets identified as a non-transactional system, because read-only can also be defined as a btrfs attribute

This PR changes the is_transactional check in the snapper plugin to actually check if / is read-only, returning true if you cannot write to /

This will work regardless of the mechanism for setting root as read-only

This should help fix issues like #263 on Aeon which _only_ uses the btrfs ro attribute and not the mount/fstab ro attribute as defining both can cause kernel race conditions.