### PR TITLE
Determine if is transactional checking read-only-root-fs

### DIFF
--- a/10-sdbootutil.snapper
+++ b/10-sdbootutil.snapper
@@ -6,7 +6,9 @@ set -e
 # check whether it's a transactional system
 is_transactional()
 {
-	[ ! -w /usr ] && [ -w /etc ]
+	# Mostly wrong check, but others are "wronger".  Waiting for a
+	# configuation file.
+	[ -d /usr/share/licenses/read-only-root-fs ]
 }
 
 # when creating a snapshot we fetch all bls configs from previous snapshot dir,

--- a/sdbootutil
+++ b/sdbootutil
@@ -333,7 +333,9 @@ reset_rollback()
 
 is_transactional()
 {
-	[ ! -w /usr ] && [ -w /etc ]
+	# Mostly wrong check, but others are "wronger".  Waiting for a
+	# configuation file.
+	[ -d /usr/share/licenses/read-only-root-fs ]
 }
 
 keyctl_add_with_timeout()


### PR DESCRIPTION
To determine if we are in a transactional system we can check if fstab is marking / as ro.  This works in MicroOS but not in Aeon.

The current check of non-writable /usr is also broken when the image is building, as /usr can be writable for a period of time.

Checking if the read-only-root-fs via RPM mostly works, but has the risk of interferring with the scriptlets.

A future configuration file, of a fix in the fstab marker (ro=vfs?) can provide a more robust check.