### PR TITLE
Show in title that it's the initial version for transactional systems

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -1050,7 +1050,9 @@ install_kernel()
 	sort_key="$os_release_ID"
 
 	add_version_to_title
-	if ! is_transactional && subvol_is_ro "$subvol"; then
+	if is_transactional && [ "$snapshot" = 1 ]; then
+		title="${title} (Initial Installation)"
+	elif ! is_transactional && subvol_is_ro "$subvol"; then
 		set_snapper_title_and_sortkey "$snapshot"
 	elif is_grub2_bls; then
 		add_kernel_version_to_title


### PR DESCRIPTION
Attempts to fix #84 

The boot menu will look like this with the change:
![IMG_20250721_172037](https://github.com/user-attachments/assets/0f1b69d6-406d-40c2-accf-a2849ec186c0)

The sorting is correct, but the version will never be shown for the initial snapshot - but I don't think that this should be a huge deal.
Not tested with grub2