### PR TITLE
measure-pcr-validator.service: Fix triggering OnFailure

### DIFF
--- a/measure-pcr-validator.service
+++ b/measure-pcr-validator.service
@@ -6,7 +6,7 @@ FailureAction=poweroff-immediate
 
 Wants=cryptsetup.target
 After=cryptsetup.target
-Before=local-fs.target
+Before=initrd-root-device.target
 
 [Service]
 Type=oneshot
@@ -18,5 +18,5 @@ StandardOutput=tty
 StandardInput=tty
 
 [Install]
-# If we use RequiredBy we trigger the debug shell
-WantedBy=local-fs.target
+# If we use RequiredBy we trigger its OnFailure=emergency.target
+WantedBy=initrd-root-device.target

--- a/measure-pcr-validator.service
+++ b/measure-pcr-validator.service
@@ -2,7 +2,7 @@
 Description=Validate LUKS2 devices
 DefaultDependencies=false
 
-OnFailure=systemd-halt.service
+FailureAction=poweroff-immediate
 
 Wants=cryptsetup.target
 After=cryptsetup.target


### PR DESCRIPTION
- Use poweroff.target to stop other services properly (they have Conflicts
on shutdown.target).
- Run after initrd-root-device.target: local-fs.target in the initrd refers to the initrd's file system and
does not make much sense here. Use initrd-root-device.target instead.