### PR TITLE
sdbootutil-enroll: support agetty for issue.d, too

### DIFF
--- a/sdbootutil-enroll
+++ b/sdbootutil-enroll
@@ -21,15 +21,15 @@ write_issue_file()
 {
 	local recovery_key="$1"
 
+	mkdir -p "/run/issue.d/"
 	if [ -e '/usr/sbin/issue-generator' ]; then
-		mkdir -p "/run/issue.d/"
 		issuefile="/run/issue.d/90-diskencrypt.conf"
 	else
-		issuefile='/dev/stdout'
+		issuefile="/run/issue.d/90-diskencrypt.issue"
 	fi
 
 	echo "$recovery_key" > "$issuefile"
-	issue-generator
+	test -x /usr/sbin/issue-generator && issue-generator
 }
 
 


### PR DESCRIPTION
Currently sdbootutil-enroll creates only a snippet for the issue file with the recovery key if issue-generator exists, but calls that later unconditonally.
If issue-generator is not installed, create a snippet for agetty and don't call issue-generator.