### PR TITLE
Fix wrong shim and bootloader path

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -3782,7 +3782,7 @@ if [ "$SECURE_BOOT" = "yes" ] || is_shim_installed; then
 fi
 
 if [ "$UPDATE_NVRAM" = "no" ]; then
-	arg_portable=1
+	arg_no_variables=1
 fi
 
 # Keep initial components before they are replaced by some actions


### PR DESCRIPTION
Quoting from the commit:

> The variable introduced by /etc/sysconfig/bootloader was responsible for
    setting arg_portable and therefore implied the bootloader path.
    Non-portable devices might have this variable set as well.  Therefore,
    it should not influence this path.

The variable `UPDATE_NVRAM=no` was set by Yast2 and leads to the wrong path being detected. I have a shim installed and use systemd-boot. Using sdboot to update my predictions, leads to the wrong shim and bootloader paths being used and updating fails with the following error.

> Failed to open '/boot/efi/EFI/BOOT/grub.efi': No such file or directory

The [following line](https://github.com/openSUSE/sdbootutil/blob/2fd41f05c93e007413279b9eb41068423292f7c1/sdbootutil#L2525) causes the shim and bootloader path to be set to the following:

> arg_portable=1
    shim_path=/boot/efi/EFI/BOOT/BOOTX64.EFI
    bootloader_path=/boot/efi/EFI/BOOT/grub.efi

Notably, the shim path exists on my system. I think it has been installed via Yast or by trying to solve my issues with updating the PCR registers, but it's still the wrong path.

This commit causes the paths to be set appropriately and solves one of my issues.

> arg_portable=
   shim_path=/boot/efi/EFI/systemd/shim.efi
   bootloader_path=/boot/efi/EFI/systemd/grub.efi

---

Additionally, the EFI variables should probably not be set when this configuration option is found.