### PR TITLE
Fix device not marked as portable

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -3773,6 +3773,7 @@ fi
 if [ "$1" != "install" ] && [ ! -d "${boot_root}${boot_dst}" ]; then
 	info "Removable installation detected"
 	boot_dst="/EFI/BOOT"
+	arg_portable=1
 fi
 
 dbg_var "boot_dst"


### PR DESCRIPTION
sdbootutil warns that a device is portable but doesn't update the appropriate variable.  This commit sets `$arg_portable` when a removable device is recognised