### PR TITLE
Don't mount /etc in chroot with btrfs subvolume

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -763,6 +763,10 @@ mount_chroot()
 	rm "$tmpdir/mounts"
 
 	mount -t tmpfs -o size=10m tmpfs "$snapshot_dir/run"
+	if [ -e /run/systemd/journal ]; then
+		mkdir -p "$snapshot_dir/run/systemd/journal"
+		mount --bind /run/systemd/journal "$snapshot_dir/run/systemd/journal"
+	fi
 	for i in proc dev sys tmp; do
 		mount --bind "/$i" "$snapshot_dir/$i"
 	done

--- a/sdbootutil
+++ b/sdbootutil
@@ -756,6 +756,7 @@ mount_chroot()
 		# shellcheck disable=SC2153
 		[ "$FSTYPE" = "btrfs" ] || [ "$FSTYPE" = "vfat" ] || [ "$FSTYPE" = "xfs" ] || [[ "$FSTYPE" == ext* ]] || continue
 		[ "$TARGET" != "/" ] || continue
+		[ "$TARGET" = "/etc" ] && [ "$FSTYPE" = "btrfs" ] && continue
 		[[ "$TARGET" != /.snapshots* ]] || continue
 		mountpoint --quiet "$snapshot_dir$TARGET" || mount --bind "$TARGET" "$snapshot_dir$TARGET"
 	done < "$tmpdir/mounts"


### PR DESCRIPTION
This is an oversight from the migration to the btrfs subvolume based layout of /etc (PR #196): With the change the code would now suddenly mount /etc, and even more unfortunately that one of the current snapshot. Just skip /etc if it's identified as a btrfs mount. The code is only executed on read-only systems, so this is a valid limitation.