### PR TITLE
Do not always install the dracut module in hostonly mode

### DIFF
--- a/module-setup.sh
+++ b/module-setup.sh
@@ -4,6 +4,12 @@
 check() {
     # Return 255 to only include the module, if another module
     # requires it.
+    if [ -n "$hostonly" ]; then
+        if ! [ -d /sys/class/tpmrm ] || [ -z "$(ls -A /sys/class/tpmrm)" ]; then
+            return 255
+        fi
+    fi
+
     return 0
 }
 


### PR DESCRIPTION
For hostonly initrds, check that the system has a TPM2 device. This check does not affect generic initrds.