### PR TITLE
sdbootutil: ignore devices that aren't listed in /etc/crypttab

### DIFF
--- a/sdbootutil
+++ b/sdbootutil
@@ -3085,8 +3085,11 @@ detect_tracked_devices()
 	while read -r dev fstype uuid; do
 		[ "$fstype" = 'crypto_LUKS' ] || continue
 		cryptsetup isLuks --type luks2 "$dev" || continue
-		[ -e /etc/crypttab ] && grep -E -q "${dev}[[:space:]].*x-sdbootutil.ignore" /etc/crypttab && continue
-		[ -e /etc/crypttab ] && grep -E -q "${uuid}[[:space:]].*x-sdbootutil.ignore" /etc/crypttab && continue
+		if [ -e /etc/crypttab ]; then
+			grep -E -q "(${dev}|${uuid})" /etc/crypttab || continue
+			grep -E -q "${dev}[[:space:]].*x-sdbootutil.ignore" /etc/crypttab && continue
+			grep -E -q "${uuid}[[:space:]].*x-sdbootutil.ignore" /etc/crypttab && continue
+		fi
 		dbg "Tracking encrypted device $dev"
 		tracked_devices+=("$dev")
 	done < <(lsblk --noheadings -o PATH,FSTYPE,UUID)


### PR DESCRIPTION
Simply adding an external device (e.g. USB stick) with a LUKS2-encrypted
partition to a system may cause sdbootutil to fail.
E.g. systemd-cryptenroll will ask the user for a password where it
normally wouldn't.

As sdbootutil is meant to handle the devices the system needs for booting,
and expects the pass phrase for all handled devices to be the same, it
makes no sense for it to try and handle external devices. On the other hand,
It makes a lot of sense for users to add all devices that are necessary
for booting to the /etc/crypttab file. Therefore ignoring devices which
are not listen in /etc/crypttab shouldn't have negative effeccts on the system.

sdbootutil already supports excluding partitions that are marked with
`x-sdbootutil.ignore` in /etc/crypttab. But that requires that users list
every external LUKS2 device in their crypttab files, which is usually not
desired, because it has effects on system boot.

Therefore simply ignore LUKS2 devices that aren't listed in /etc/crypttab.

Fixes: https://github.com/openSUSE/sdbootutil/issues/347

(Note: this PR includes #346)